### PR TITLE
fix: add Logger and corresponding setup

### DIFF
--- a/core/inc/knoting/log.h
+++ b/core/inc/knoting/log.h
@@ -9,6 +9,11 @@ namespace log {
 
 using namespace spdlog;
 
+class Logger {
+   public:
+    static void setup();
+};
+
 }  // namespace log
 
 }  // namespace knot

--- a/core/src/log.cpp
+++ b/core/src/log.cpp
@@ -1,0 +1,29 @@
+#include <knoting/log.h>
+
+#include <spdlog/sinks/stdout_color_sinks.h>
+
+namespace knot {
+
+namespace log {
+
+void Logger::setup() {
+#ifdef KNOTING_DEBUG
+    log::set_level(spdlog::level::debug);
+#endif
+
+    log::default_logger()->sinks().clear();
+    log::default_logger()->sinks().push_back(std::make_shared<log::sinks::stdout_color_sink_st>());
+
+    // %R: 24-hour time (HH:MM)/(Hour:Minutes)
+    // %S: seconds
+    // %e: milliseconds
+    // %^: start color
+    // %l: level
+    // %$: end color
+    // %v: message
+    log::set_pattern("[%R:%S:%e] [%^%l%$]: %v");
+}
+
+}  // namespace log
+
+}  // namespace knot

--- a/untie/src/main.cpp
+++ b/untie/src/main.cpp
@@ -5,7 +5,8 @@
 using namespace knot;
 
 int main() {
-    log::debug("Hi there");
+    log::Logger::setup();
+
     Window window(1280, 720, "Knoting");
 
     while (window.is_open()) {


### PR DESCRIPTION
Add `log.cpp` which includes class `Logger` with a static setup function.
Clear all current sinks and add a `stdout_color_sink_st` type sink.

This Logger should be expanded in the future, whenever we need a log file, or an in-editor console.