### PR TITLE
Asset manager / Lights / Light Data / Assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ scene.json
 # Object files
 *.o
 *.ko
-*.obj
+# *.obj
 *.elf
 
 # Linker output

--- a/core/inc/knoting/asset.h
+++ b/core/inc/knoting/asset.h
@@ -5,7 +5,7 @@
 
 static constexpr char PATH_SHADER[] = "../res/shaders/";
 static constexpr char PATH_TEXTURE[] = "../res/textures/";
-static constexpr char PATH_MODELS[] = "../res/models/";
+static constexpr char PATH_MODELS[] = "../res/misc/";
 
 namespace knot {
 using namespace asset;

--- a/core/inc/knoting/asset.h
+++ b/core/inc/knoting/asset.h
@@ -10,15 +10,18 @@ static constexpr char PATH_MODELS[] = "../res/models/";
 namespace knot {
 using namespace asset;
 
-enum class AssetState { IDLE, LOADING, FINISHED, FAILED };
 
 class Asset {
    public:
     Asset(AssetType assetType, const std::string& path);
     virtual void on_awake() = 0;
     virtual void on_destroy() = 0;
+
+    AssetState get_asset_state(){return m_assetState;};
+
    protected:
     AssetType m_assetType = AssetType::UNKNOWN;
+    AssetState m_assetState = AssetState::IDLE;
 
     std::string m_fullPath;
     std::string m_assetName;

--- a/core/inc/knoting/asset.h
+++ b/core/inc/knoting/asset.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <string>
 #include <knoting/types.h>
+#include <string>
 
 static constexpr char PATH_SHADER[] = "../res/shaders/";
 static constexpr char PATH_TEXTURE[] = "../res/textures/";
@@ -10,7 +10,7 @@ static constexpr char PATH_MODELS[] = "../res/models/";
 namespace knot {
 using namespace asset;
 
-enum class AssetState { IDLE, LOADING, FINISHED, FAILED};
+enum class AssetState { IDLE, LOADING, FINISHED, FAILED };
 
 class Asset {
    public:

--- a/core/inc/knoting/asset.h
+++ b/core/inc/knoting/asset.h
@@ -19,9 +19,14 @@ class Asset {
 
     AssetState get_asset_state(){return m_assetState;};
 
+    std::string fallback_name(){
+
+    }
+
    protected:
     AssetType m_assetType = AssetType::UNKNOWN;
     AssetState m_assetState = AssetState::IDLE;
+
 
     std::string m_fullPath;
     std::string m_assetName;

--- a/core/inc/knoting/asset.h
+++ b/core/inc/knoting/asset.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <string>
+#include <knoting/types.h>
+
+static constexpr char PATH_SHADER[] = "../res/shaders/";
+static constexpr char PATH_TEXTURE[] = "../res/textures/";
+static constexpr char PATH_MODELS[] = "../res/models/";
+
+namespace knot {
+using namespace asset;
+
+enum class AssetState { IDLE, LOADING, FINISHED, FAILED};
+
+class Asset {
+   public:
+    Asset(AssetType assetType, const std::string& path);
+
+   private:
+    AssetType m_assetType = AssetType::UNKNOWN;
+
+    std::string m_fullPath;
+    std::string m_assetName;
+    std::string m_assetDirectory;
+};
+
+}  // namespace knot

--- a/core/inc/knoting/asset.h
+++ b/core/inc/knoting/asset.h
@@ -15,8 +15,8 @@ enum class AssetState { IDLE, LOADING, FINISHED, FAILED };
 class Asset {
    public:
     Asset(AssetType assetType, const std::string& path);
-
-   private:
+    virtual void on_awake() = 0;
+   protected:
     AssetType m_assetType = AssetType::UNKNOWN;
 
     std::string m_fullPath;

--- a/core/inc/knoting/asset.h
+++ b/core/inc/knoting/asset.h
@@ -10,23 +10,21 @@ static constexpr char PATH_MODELS[] = "../res/models/";
 namespace knot {
 using namespace asset;
 
-
 class Asset {
    public:
-    Asset(AssetType assetType, const std::string& path);
+    Asset(AssetType assetType, const std::string& path, const std::string& fallbackName);
     virtual void on_awake() = 0;
     virtual void on_destroy() = 0;
+    virtual void generate_default_asset() = 0;
 
-    AssetState get_asset_state(){return m_assetState;};
-
-    std::string fallback_name(){
-
-    }
+    AssetState get_asset_state() { return m_assetState; };
+    std::string get_fallback_name() { return m_fallbackName; };
 
    protected:
     AssetType m_assetType = AssetType::UNKNOWN;
     AssetState m_assetState = AssetState::IDLE;
 
+    std::string m_fallbackName = "SET_IN_DERIVED_IMPLEMENTATION";
 
     std::string m_fullPath;
     std::string m_assetName;

--- a/core/inc/knoting/asset.h
+++ b/core/inc/knoting/asset.h
@@ -16,6 +16,7 @@ class Asset {
    public:
     Asset(AssetType assetType, const std::string& path);
     virtual void on_awake() = 0;
+    virtual void on_destroy() = 0;
    protected:
     AssetType m_assetType = AssetType::UNKNOWN;
 

--- a/core/inc/knoting/asset.h
+++ b/core/inc/knoting/asset.h
@@ -21,8 +21,8 @@ class Asset {
     std::string get_fallback_name() { return m_fallbackName; };
 
    protected:
-    AssetType m_assetType = AssetType::UNKNOWN;
-    AssetState m_assetState = AssetState::IDLE;
+    AssetType m_assetType = AssetType::Unknown;
+    AssetState m_assetState = AssetState::Idle;
 
     std::string m_fallbackName = "SET_IN_DERIVED_IMPLEMENTATION";
 

--- a/core/inc/knoting/asset.h
+++ b/core/inc/knoting/asset.h
@@ -3,16 +3,21 @@
 #include <knoting/types.h>
 #include <string>
 
-static constexpr char PATH_SHADER[] = "../res/shaders/";
 static constexpr char PATH_TEXTURE[] = "../res/textures/";
 static constexpr char PATH_MODELS[] = "../res/misc/";
+static constexpr char PATH_SHADER[] = "../res/shaders/";
+
+static constexpr char fallbackTextureName[] = "fallbackTexture";
+static constexpr char fallbackMeshName[] = "fallbackMesh";
+static constexpr char fallbackShaderName[] = "fallbackShader";
+static constexpr char fallbackCubeMapName[] = "fallbackCubeMap";
 
 namespace knot {
 using namespace asset;
 
 class Asset {
    public:
-    Asset(AssetType assetType, const std::string& path, const std::string& fallbackName);
+    Asset(AssetType assetType, const std::string& path);
     virtual void on_awake() = 0;
     virtual void on_destroy() = 0;
     virtual void generate_default_asset() = 0;
@@ -20,11 +25,14 @@ class Asset {
     AssetState get_asset_state() { return m_assetState; };
     std::string get_fallback_name() { return m_fallbackName; };
 
+   private:
+    void set_fallback_name(AssetType type);
+
    protected:
     AssetType m_assetType = AssetType::Unknown;
     AssetState m_assetState = AssetState::Idle;
 
-    std::string m_fallbackName = "SET_IN_DERIVED_IMPLEMENTATION";
+    std::string m_fallbackName;
 
     std::string m_fullPath;
     std::string m_assetName;

--- a/core/inc/knoting/asset_loaders/image_loader.h
+++ b/core/inc/knoting/asset_loaders/image_loader.h
@@ -7,8 +7,6 @@ using namespace asset;
 
 class ImageLoader {
    public:
-
    private:
-
 };
 }  // namespace knot

--- a/core/inc/knoting/asset_loaders/image_loader.h
+++ b/core/inc/knoting/asset_loaders/image_loader.h
@@ -1,0 +1,14 @@
+
+#pragma once
+#include <knoting/asset.h>
+
+namespace knot {
+using namespace asset;
+
+class ImageLoader {
+   public:
+
+   private:
+
+};
+}  // namespace knot

--- a/core/inc/knoting/asset_loaders/model_loader.h
+++ b/core/inc/knoting/asset_loaders/model_loader.h
@@ -1,0 +1,14 @@
+
+#pragma once
+#include <knoting/asset.h>
+
+namespace knot {
+using namespace asset;
+
+class ModelLoader {
+   public:
+
+   private:
+
+};
+}  // namespace knot

--- a/core/inc/knoting/asset_loaders/model_loader.h
+++ b/core/inc/knoting/asset_loaders/model_loader.h
@@ -7,8 +7,6 @@ using namespace asset;
 
 class ModelLoader {
    public:
-
    private:
-
 };
 }  // namespace knot

--- a/core/inc/knoting/asset_manager.h
+++ b/core/inc/knoting/asset_manager.h
@@ -41,10 +41,8 @@ class AssetManager : public Subsystem {
    private:
     template <typename T>
     inline std::weak_ptr<T> internal_load_asset(const std::string& path) {
-        if (!std::is_base_of<Asset, T>::value) {
-            log::error("ASSET : " + path + " IS NOT OF BASE CLASS ASSET");
-        }
-
+        static_assert(!std::is_base_of<T, Asset>::value, "ASSET IS NOT OF BASE CLASS ASSET");
+        
         auto iterator = m_assets.find(path);
 
         if (iterator == m_assets.end()) {

--- a/core/inc/knoting/asset_manager.h
+++ b/core/inc/knoting/asset_manager.h
@@ -1,0 +1,42 @@
+#pragma once
+#include <knoting/assert.h>
+#include <knoting/asset.h>
+#include <knoting/log.h>
+#include <knoting/subsystem.h>
+#include <knoting/types.h>
+#include <uuid.h>
+
+#include <knoting/mesh.h>
+#include <knoting/shader_program.h>
+#include <knoting/texture.h>
+
+namespace knot {
+using namespace asset;
+
+class AssetManager : public Subsystem {
+   public:
+
+    void on_awake() override;
+    void on_destroy() override;
+
+    void load_assets_manual();
+    void load_assets_serialize();
+
+    template <typename T, typename... TArgs>
+    inline std::weak_ptr<T> load_asset(const std::string& path) {
+        if (!std::is_base_of<Asset, T>::value) {
+            log::error("ASSET : " + path + " IS NOT OF BASE CLASS ASSET");
+        }
+        auto iterator = m_assets.find(path);
+        if (iterator == m_assets.end()) {
+            log::debug("Asset : " + path + " is being created");
+            m_assets[path] = std::make_shared<T>(path);
+        }
+        return std::static_pointer_cast<T>(m_assets[path]);
+    }
+
+   private:
+    //TODO consider tuple / UUID for when assets are loaded via serialization
+    std::map<std::string, std::shared_ptr<Asset>> m_assets;
+};
+}  // namespace knot

--- a/core/inc/knoting/asset_manager.h
+++ b/core/inc/knoting/asset_manager.h
@@ -20,8 +20,6 @@ class AssetManager : public Subsystem {
     void on_awake() override;
     void on_destroy() override;
 
-    virtual void on_update(double m_delta_time);
-
     void load_assets_manual();
     void load_assets_serialize();
 
@@ -41,15 +39,12 @@ class AssetManager : public Subsystem {
         }
         auto iterator = m_assets.find(path);
         if (iterator == m_assets.end()) {
-            log::debug("Asset : " + path + " is being created");
+            log::debug("Asset : " + path + " is being loaded");
             m_assets.insert({path, std::make_shared<T>(path)});
             auto result = std::static_pointer_cast<T>(m_assets[path]);
             result.get()->on_awake();
             //TODO return fallback asset
             return result;
-        }
-        else{
-            log::info("FOUND Asset : " + path + " FOUND");
         }
         return std::static_pointer_cast<T>(m_assets[path]);
     }

--- a/core/inc/knoting/asset_manager.h
+++ b/core/inc/knoting/asset_manager.h
@@ -47,6 +47,7 @@ class AssetManager : public Subsystem {
                 std::shared_ptr<T> result = std::static_pointer_cast<T>(m_assets[tempAsset.get_fallback_name()]);
                 return result;
             } else {
+                log::info("Found asset: {}",path);
                 m_assets.insert({path, std::make_shared<T>(tempAsset)});
                 std::shared_ptr<T> result = std::static_pointer_cast<T>(m_assets[path]);
                 result.get()->on_awake();

--- a/core/inc/knoting/asset_manager.h
+++ b/core/inc/knoting/asset_manager.h
@@ -43,6 +43,7 @@ class AssetManager : public Subsystem {
             m_assets.insert({path, std::make_shared<T>(path)});
             auto result = std::static_pointer_cast<T>(m_assets[path]);
             result.get()->on_awake();
+            if (result.get())
             //TODO return fallback asset
             return result;
         }

--- a/core/inc/knoting/asset_manager.h
+++ b/core/inc/knoting/asset_manager.h
@@ -15,14 +15,22 @@ using namespace asset;
 
 class AssetManager : public Subsystem {
    public:
-
     void on_awake() override;
     void on_destroy() override;
 
     void load_assets_manual();
     void load_assets_serialize();
 
-    template <typename T, typename... TArgs>
+    static std::optional<std::reference_wrapper<AssetManager>> get_asset_manager() { return s_assetManager; };
+
+   private:
+    // TODO consider tuple / UUID for when assets are loaded via serialization
+    std::map<std::string, std::shared_ptr<Asset>> m_assets;
+
+    inline static std::optional<std::reference_wrapper<AssetManager>> s_assetManager = std::nullopt;
+
+   public:
+    template <typename T>
     inline std::weak_ptr<T> load_asset(const std::string& path) {
         if (!std::is_base_of<Asset, T>::value) {
             log::error("ASSET : " + path + " IS NOT OF BASE CLASS ASSET");
@@ -34,9 +42,5 @@ class AssetManager : public Subsystem {
         }
         return std::static_pointer_cast<T>(m_assets[path]);
     }
-
-   private:
-    //TODO consider tuple / UUID for when assets are loaded via serialization
-    std::map<std::string, std::shared_ptr<Asset>> m_assets;
 };
 }  // namespace knot

--- a/core/inc/knoting/asset_manager.h
+++ b/core/inc/knoting/asset_manager.h
@@ -37,25 +37,23 @@ class AssetManager : public Subsystem {
         if (!std::is_base_of<Asset, T>::value) {
             log::error("ASSET : " + path + " IS NOT OF BASE CLASS ASSET");
         }
-        std::string mapPath = path;
-        auto iterator = m_assets.find(mapPath);
+        auto iterator = m_assets.find(path);
         if (iterator == m_assets.end()) {
-            log::debug("Asset : " + mapPath + " is being loaded");
-            T tempAsset = T(mapPath);
+            log::debug("Asset : " + path + " is being loaded");
+            T tempAsset = T(path);
             tempAsset.on_awake();
-            if (tempAsset.get_asset_state() == AssetState::FAILED){
-                log::error("ASSET MANAGER FAILED TO LOAD");
-                std::shared_ptr<T> result = std::static_pointer_cast<T>(m_assets["fallbackTexture"]);
+            if (tempAsset.get_asset_state() == AssetState::FAILED) {
+                log::warn("ASSET MANAGER FAILED TO LOAD");
+                std::shared_ptr<T> result = std::static_pointer_cast<T>(m_assets[tempAsset.get_fallback_name()]);
                 return result;
-            }
-            else{
-                m_assets.insert({mapPath, std::make_shared<T>(tempAsset)});
-                std::shared_ptr<T> result = std::static_pointer_cast<T>(m_assets[mapPath]);
+            } else {
+                m_assets.insert({path, std::make_shared<T>(tempAsset)});
+                std::shared_ptr<T> result = std::static_pointer_cast<T>(m_assets[path]);
                 result.get()->on_awake();
                 return result;
             }
         }
-        return std::static_pointer_cast<T>(m_assets[mapPath]);
+        return std::static_pointer_cast<T>(m_assets[path]);
     }
 
    public:

--- a/core/inc/knoting/asset_manager.h
+++ b/core/inc/knoting/asset_manager.h
@@ -42,7 +42,7 @@ class AssetManager : public Subsystem {
             log::debug("Asset : " + path + " is being loaded");
             T tempAsset = T(path);
             tempAsset.on_awake();
-            if (tempAsset.get_asset_state() == AssetState::FAILED) {
+            if (tempAsset.get_asset_state() == AssetState::Failed) {
                 log::warn("ASSET MANAGER FAILED TO LOAD");
                 std::shared_ptr<T> result = std::static_pointer_cast<T>(m_assets[tempAsset.get_fallback_name()]);
                 return result;

--- a/core/inc/knoting/asset_manager.h
+++ b/core/inc/knoting/asset_manager.h
@@ -42,7 +42,7 @@ class AssetManager : public Subsystem {
     template <typename T>
     inline std::weak_ptr<T> internal_load_asset(const std::string& path) {
         static_assert(!std::is_base_of<T, Asset>::value, "ASSET IS NOT OF BASE CLASS ASSET");
-        
+
         auto iterator = m_assets.find(path);
 
         if (iterator == m_assets.end()) {

--- a/core/inc/knoting/asset_manager.h
+++ b/core/inc/knoting/asset_manager.h
@@ -17,6 +17,7 @@ class AssetManager : public Subsystem {
    public:
     AssetManager() = default;
     AssetManager(const AssetManager& other) = delete;
+
     void on_awake() override;
     void on_destroy() override;
 
@@ -25,10 +26,16 @@ class AssetManager : public Subsystem {
 
     static std::optional<std::reference_wrapper<AssetManager>> get_asset_manager() { return s_assetManager; };
 
-   private:
-    // TODO consider tuple / UUID for when assets are loaded via serialization
-    std::map<std::string, std::shared_ptr<Asset>> m_assets;
+    template <typename T>
+    inline static std::weak_ptr<T> load_asset(const std::string& path) {
+        auto managerOpt = get_asset_manager();
+        KNOTING_ASSERT_MESSAGE(managerOpt.has_value(), "ASSET MANAGER IS EMPTY")
+        auto& assetManager = managerOpt->get();
+        return assetManager.internal_load_asset<T>(path);
+    }
 
+   private:
+    std::map<std::string, std::shared_ptr<Asset>> m_assets;
     inline static std::optional<std::reference_wrapper<AssetManager>> s_assetManager = std::nullopt;
 
    private:
@@ -37,15 +44,17 @@ class AssetManager : public Subsystem {
         if (!std::is_base_of<Asset, T>::value) {
             log::error("ASSET : " + path + " IS NOT OF BASE CLASS ASSET");
         }
+
         auto iterator = m_assets.find(path);
+
         if (iterator == m_assets.end()) {
             log::debug("Asset : " + path + " is being loaded");
             std::shared_ptr<T> tempAsset = std::make_shared<T>(path);
             tempAsset.get()->on_awake();
+
             if (tempAsset.get()->get_asset_state() == AssetState::Failed) {
                 log::warn("Asset manager failed to load {} loading fallback");
-                std::shared_ptr<T> result = std::static_pointer_cast<T>(m_assets[tempAsset.get()->get_fallback_name()]);
-                return result;
+                return std::static_pointer_cast<T>(m_assets[tempAsset.get()->get_fallback_name()]);
             } else {
                 log::info("adding asset: {}", path);
                 m_assets.insert({path, tempAsset});
@@ -58,43 +67,6 @@ class AssetManager : public Subsystem {
         auto r = std::static_pointer_cast<T>(m_assets[path]);
         r->on_awake();
         return r;
-    }
-
-    inline std::weak_ptr<components::Mesh> internal_load_asset(const std::string& path) {
-        if (!std::is_base_of<Asset, components::Mesh>::value) {
-            log::error("ASSET : " + path + " IS NOT OF BASE CLASS ASSET");
-        }
-        auto iterator = m_assets.find(path);
-        if (iterator == m_assets.end()) {
-            log::debug("Asset : " + path + " is being loaded");
-            components::Mesh tempAsset = components::Mesh(path);
-            tempAsset.on_awake();
-            if (tempAsset.get_asset_state() == AssetState::Failed) {
-                log::warn("ASSET MANAGER FAILED TO LOAD");
-                std::shared_ptr<components::Mesh> result =
-                    std::static_pointer_cast<components::Mesh>(m_assets[tempAsset.get_fallback_name()]);
-                return result;
-            } else {
-                log::info("adding asset: {}", path);
-                m_assets.insert({path, std::make_shared<components::Mesh>(tempAsset)});
-                std::shared_ptr<components::Mesh> result = std::static_pointer_cast<components::Mesh>(m_assets[path]);
-                result.get()->on_awake();
-                return result;
-            }
-        }
-        log::info("asset [ {} ] was found", path);
-        auto r = std::static_pointer_cast<components::Mesh>(m_assets[path]);
-        r->on_awake();
-        return r;
-    }
-
-   public:
-    template <typename T>
-    inline static std::weak_ptr<T> load_asset(const std::string& path) {
-        auto managerOpt = get_asset_manager();
-        KNOTING_ASSERT_MESSAGE(managerOpt.has_value(), "ASSET MANAGER IS EMPTY")
-        auto& assetManager = managerOpt->get();
-        return assetManager.internal_load_asset<T>(path);
     }
 };
 }  // namespace knot

--- a/core/inc/knoting/asset_manager.h
+++ b/core/inc/knoting/asset_manager.h
@@ -37,17 +37,25 @@ class AssetManager : public Subsystem {
         if (!std::is_base_of<Asset, T>::value) {
             log::error("ASSET : " + path + " IS NOT OF BASE CLASS ASSET");
         }
-        auto iterator = m_assets.find(path);
+        std::string mapPath = path;
+        auto iterator = m_assets.find(mapPath);
         if (iterator == m_assets.end()) {
-            log::debug("Asset : " + path + " is being loaded");
-            m_assets.insert({path, std::make_shared<T>(path)});
-            auto result = std::static_pointer_cast<T>(m_assets[path]);
-            result.get()->on_awake();
-            if (result.get())
-            //TODO return fallback asset
-            return result;
+            log::debug("Asset : " + mapPath + " is being loaded");
+            T tempAsset = T(mapPath);
+            tempAsset.on_awake();
+            if (tempAsset.get_asset_state() == AssetState::FAILED){
+                log::error("ASSET MANAGER FAILED TO LOAD");
+                std::shared_ptr<T> result = std::static_pointer_cast<T>(m_assets["fallbackTexture"]);
+                return result;
+            }
+            else{
+                m_assets.insert({mapPath, std::make_shared<T>(tempAsset)});
+                std::shared_ptr<T> result = std::static_pointer_cast<T>(m_assets[mapPath]);
+                result.get()->on_awake();
+                return result;
+            }
         }
-        return std::static_pointer_cast<T>(m_assets[path]);
+        return std::static_pointer_cast<T>(m_assets[mapPath]);
     }
 
    public:

--- a/core/inc/knoting/engine.h
+++ b/core/inc/knoting/engine.h
@@ -8,6 +8,7 @@
 #include <knoting/forward_renderer.h>
 #include <knoting/subsystem.h>
 #include <knoting/window.h>
+#include <knoting/asset_manager.h>
 
 namespace knot {
 class Engine {
@@ -30,6 +31,7 @@ class Engine {
     std::vector<std::shared_ptr<Subsystem>> m_engineModules;
     std::shared_ptr<Window> m_windowModule;
     std::shared_ptr<ForwardRenderer> m_forwardRenderModule;
+    std::shared_ptr<AssetManager> m_assetManager;
 };
 
 }  // namespace knot

--- a/core/inc/knoting/engine.h
+++ b/core/inc/knoting/engine.h
@@ -5,10 +5,10 @@
 #include <string>
 #include <vector>
 
+#include <knoting/asset_manager.h>
 #include <knoting/forward_renderer.h>
 #include <knoting/subsystem.h>
 #include <knoting/window.h>
-#include <knoting/asset_manager.h>
 
 namespace knot {
 class Engine {

--- a/core/inc/knoting/forward_renderer.h
+++ b/core/inc/knoting/forward_renderer.h
@@ -39,6 +39,10 @@ class ForwardRenderer : public Subsystem {
 
     Engine& m_engine;
 
+    bgfx::UniformHandle u_lightPosRadius;
+    bgfx::UniformHandle u_lightRgbInnerR;
+    uint16_t m_numLights;
+
    private:
     static constexpr uint32_t m_clearColor = 0x303030ff;
     float m_timePassed = 0.01f;

--- a/core/inc/knoting/forward_renderer.h
+++ b/core/inc/knoting/forward_renderer.h
@@ -37,26 +37,11 @@ class ForwardRenderer : public Subsystem {
     int get_window_width();
     int get_window_height();
 
-    components::ShaderProgram m_shaderProgram;
-    components::Mesh m_cube;
-    components::Texture m_colorTexture;
-    components::Texture m_normalTexture;
-
     Engine& m_engine;
 
    private:
     static constexpr uint32_t m_clearColor = 0x303030ff;
     float m_timePassed = 0.01f;
-
-    // TODO move to pipeline class
-    bgfx::UniformHandle s_texColor;
-    bgfx::UniformHandle s_texNormal;
-    bgfx::UniformHandle u_lightPosRadius;
-    bgfx::UniformHandle u_lightRgbInnerR;
-    bgfx::TextureHandle m_textureColor;
-    bgfx::TextureHandle m_textureNormal;
-    uint16_t m_numLights;
-    // end TODO
 };
 
 }  // namespace knot

--- a/core/inc/knoting/forward_renderer.h
+++ b/core/inc/knoting/forward_renderer.h
@@ -22,7 +22,6 @@ class ForwardRenderer : public Subsystem {
     ~ForwardRenderer();
 
     void on_render();
-    void render_pbr();
     void on_post_render();
 
     void on_awake() override;

--- a/core/inc/knoting/forward_renderer.h
+++ b/core/inc/knoting/forward_renderer.h
@@ -1,13 +1,13 @@
 #pragma once
 
-#include <knoting/log.h>
-#include <knoting/subsystem.h>
-#include <knoting/types.h>
-
 #include <bgfx/bgfx.h>
+#include <knoting/light_data.h>
+#include <knoting/log.h>
 #include <knoting/mesh.h>
 #include <knoting/shader_program.h>
+#include <knoting/subsystem.h>
 #include <knoting/texture.h>
+#include <knoting/types.h>
 
 namespace knot {
 
@@ -37,10 +37,7 @@ class ForwardRenderer : public Subsystem {
     int get_window_height();
 
     Engine& m_engine;
-
-    bgfx::UniformHandle u_lightPosRadius;
-    bgfx::UniformHandle u_lightRgbInnerR;
-    uint16_t m_numLights;
+    LightData m_lightData;
 
    private:
     static constexpr uint32_t m_clearColor = 0x303030ff;

--- a/core/inc/knoting/instance_mesh.h
+++ b/core/inc/knoting/instance_mesh.h
@@ -1,0 +1,28 @@
+#pragma once
+#include <knoting/asset.h>
+#include <knoting/asset_manager.h>
+#include <knoting/mesh.h>
+#include <knoting/types.h>
+#include <string>
+#include <vector>
+
+namespace knot {
+
+class InstanceMesh {
+   public:
+    InstanceMesh();
+    InstanceMesh(const std::string& path);
+
+    bgfx::VertexBufferHandle* get_vertex_buffer() { return m_instance_mesh->get_vertex_buffer(); }
+    bgfx::IndexBufferHandle* get_index_buffer() { return m_instance_mesh->get_index_buffer(); }
+
+    //=For ECS========
+    void on_awake();
+    void on_destroy();
+    //================
+    components::Mesh* get_mesh(){return m_instance_mesh.get();};
+   private:
+    std::shared_ptr<components::Mesh> m_instance_mesh;
+    std::string m_path;
+};
+}  // namespace knot

--- a/core/inc/knoting/instance_mesh.h
+++ b/core/inc/knoting/instance_mesh.h
@@ -13,16 +13,15 @@ class InstanceMesh {
     InstanceMesh();
     InstanceMesh(const std::string& path);
 
-    bgfx::VertexBufferHandle* get_vertex_buffer() { return m_instance_mesh->get_vertex_buffer(); }
-    bgfx::IndexBufferHandle* get_index_buffer() { return m_instance_mesh->get_index_buffer(); }
+    bgfx::VertexBufferHandle get_vertex_buffer() { return m_mesh->get_vertex_buffer(); }
+    bgfx::IndexBufferHandle get_index_buffer() { return m_mesh->get_index_buffer(); }
 
     //=For ECS========
     void on_awake();
     void on_destroy();
     //================
-    components::Mesh* get_mesh(){return m_instance_mesh.get();};
    private:
-    std::shared_ptr<components::Mesh> m_instance_mesh;
+    std::shared_ptr<components::Mesh> m_mesh;
     std::string m_path;
 };
 }  // namespace knot

--- a/core/inc/knoting/instance_mesh.h
+++ b/core/inc/knoting/instance_mesh.h
@@ -13,13 +13,14 @@ class InstanceMesh {
     InstanceMesh();
     InstanceMesh(const std::string& path);
 
-    bgfx::VertexBufferHandle get_vertex_buffer() { return m_mesh->get_vertex_buffer(); }
-    bgfx::IndexBufferHandle get_index_buffer() { return m_mesh->get_index_buffer(); }
-
     //=For ECS========
     void on_awake();
     void on_destroy();
     //================
+
+    bgfx::VertexBufferHandle get_vertex_buffer() { return m_mesh->get_vertex_buffer(); }
+    bgfx::IndexBufferHandle get_index_buffer() { return m_mesh->get_index_buffer(); }
+
    private:
     std::shared_ptr<components::Mesh> m_mesh;
     std::string m_path;

--- a/core/inc/knoting/light_data.h
+++ b/core/inc/knoting/light_data.h
@@ -19,7 +19,6 @@ class SpotlightData {
 };
 
 class LightData {
-
    public:
     LightData();
 
@@ -31,7 +30,5 @@ class LightData {
 
     SpotlightData m_spotlightData;
 };
-
-
 
 }  // namespace knot

--- a/core/inc/knoting/light_data.h
+++ b/core/inc/knoting/light_data.h
@@ -1,0 +1,34 @@
+#pragma once
+#include <bgfx/bgfx.h>
+#include <knoting/types.h>
+
+namespace knot {
+class LightData {
+   private:
+    class SpotlightData {
+       public:
+        SpotlightData();
+        ~SpotlightData();
+
+       public:
+        bgfx::UniformHandle u_spotlightPosRadius;
+        bgfx::UniformHandle u_spotlightRgbInnerR;
+
+        uint16_t m_amountOfSpotlights = 0;
+        std::vector<vec4> m_spotlightsPositionOuterRadius;
+        std::vector<vec4> m_spotlightsColorInnerRadius;
+    };
+
+   public:
+    LightData();
+
+    void push_spotlight_pos_outer_rad(vec4 posOutRad);
+    void push_spotlight_color_inner_rad(vec4 colInRad);
+    void set_spotlight_count(uint16_t count);
+    void set_spotlight_uniforms();
+    void clear_spotlight();
+
+    SpotlightData m_spotlightData;
+};
+
+}  // namespace knot

--- a/core/inc/knoting/light_data.h
+++ b/core/inc/knoting/light_data.h
@@ -22,8 +22,8 @@ class LightData {
    public:
     LightData();
 
-    void push_spotlight_pos_outer_rad(vec4 posOutRad);
-    void push_spotlight_color_inner_rad(vec4 colInRad);
+    void push_spotlight_pos_outer_rad(vec4 positionAndOuterRadius);
+    void push_spotlight_color_inner_rad(vec4 colorAndInnerRadius);
     void set_spotlight_count(uint16_t count);
     void set_spotlight_uniforms();
     void clear_spotlight();

--- a/core/inc/knoting/light_data.h
+++ b/core/inc/knoting/light_data.h
@@ -3,21 +3,22 @@
 #include <knoting/types.h>
 
 namespace knot {
+
+class SpotlightData {
+   public:
+    SpotlightData();
+    ~SpotlightData();
+
+   public:
+    bgfx::UniformHandle u_spotlightPosRadius;
+    bgfx::UniformHandle u_spotlightRgbInnerR;
+
+    uint16_t m_amountOfSpotlights = 0;
+    std::vector<vec4> m_spotlightsPositionOuterRadius;
+    std::vector<vec4> m_spotlightsColorInnerRadius;
+};
+
 class LightData {
-   private:
-    class SpotlightData {
-       public:
-        SpotlightData();
-        ~SpotlightData();
-
-       public:
-        bgfx::UniformHandle u_spotlightPosRadius;
-        bgfx::UniformHandle u_spotlightRgbInnerR;
-
-        uint16_t m_amountOfSpotlights = 0;
-        std::vector<vec4> m_spotlightsPositionOuterRadius;
-        std::vector<vec4> m_spotlightsColorInnerRadius;
-    };
 
    public:
     LightData();
@@ -30,5 +31,7 @@ class LightData {
 
     SpotlightData m_spotlightData;
 };
+
+
 
 }  // namespace knot

--- a/core/inc/knoting/material.h
+++ b/core/inc/knoting/material.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #include <bgfx/bgfx.h>
+#include <knoting/asset_manager.h>
 #include <knoting/shader_program.h>
 #include <knoting/texture.h>
 #include <knoting/types.h>
-#include <knoting/asset_manager.h>
 
 namespace knot {
 namespace components {
@@ -56,7 +56,7 @@ class Material {
     void on_destroy();
     //================
 
-    void set_texture_slot_path(TextureHandle slot, const std::string & path);
+    void set_texture_slot_path(TextureHandle slot, const std::string& path);
 
     void set_uniforms();
     bgfx::ProgramHandle get_program() { return m_shader.get_program(); };

--- a/core/inc/knoting/material.h
+++ b/core/inc/knoting/material.h
@@ -26,6 +26,8 @@ enum class UniformHandle {
     LAST
 };
 
+
+
 enum class TextureHandle {
     Albedo,
     Normal,
@@ -56,7 +58,7 @@ class Material {
     void on_destroy();
     //================
 
-    void set_texture_slot_path(TextureHandle slot, const std::string& path);
+    void set_texture_slot_path(TextureType slot, const std::string& path);
 
     void set_uniforms();
     bgfx::ProgramHandle get_program() { return m_shader.get_program(); };

--- a/core/inc/knoting/material.h
+++ b/core/inc/knoting/material.h
@@ -26,8 +26,6 @@ enum class UniformHandle {
     LAST
 };
 
-
-
 enum class TextureHandle {
     Albedo,
     Normal,
@@ -45,8 +43,6 @@ enum class UniformSamplerHandle {
     Occlusion,
     LAST
 };
-
-// clang-format on
 
 class Material {
    public:
@@ -80,7 +76,6 @@ class Material {
     ShaderProgram m_shader;
 
    private:
-    // TODO consider mapping uniforms to string
     glm::vec4 m_albedoColor = glm::vec4(255.0f / 255.0f, 255.0f / 255.0f, 255.0f / 255.0f, 255.0f / 255.0f);
     glm::vec2 m_textureTiling = glm::vec2(1);
 
@@ -96,7 +91,6 @@ class Material {
 
     bool m_alphaCutoffEnabled = false;
     float m_alphaCutoffAmount = 0.0f;
-    // end TODO
 };
 
 }  // namespace components

--- a/core/inc/knoting/material.h
+++ b/core/inc/knoting/material.h
@@ -4,6 +4,7 @@
 #include <knoting/shader_program.h>
 #include <knoting/texture.h>
 #include <knoting/types.h>
+#include <knoting/asset_manager.h>
 
 namespace knot {
 namespace components {
@@ -55,6 +56,8 @@ class Material {
     void on_destroy();
     //================
 
+    void set_texture_slot_path(TextureHandle slot, const std::string & path);
+
     void set_uniforms();
     bgfx::ProgramHandle get_program() { return m_shader.get_program(); };
 
@@ -64,11 +67,13 @@ class Material {
     std::array<bgfx::TextureHandle, (size_t)TextureHandle::LAST> m_textureHandles;
 
    private:
-    Texture m_albedo;
-    Texture m_normal;
-    Texture m_metallic;
-    Texture m_roughness;
-    Texture m_occlusion;
+    std::shared_ptr<Texture> m_albedo;
+    std::shared_ptr<Texture> m_normal;
+    std::shared_ptr<Texture> m_metallic;
+    std::shared_ptr<Texture> m_roughness;
+    std::shared_ptr<Texture> m_occlusion;
+
+    std::string m_textureSlotPath[5] = {"", "", "", "", ""};
 
     ShaderProgram m_shader;
 

--- a/core/inc/knoting/mesh.h
+++ b/core/inc/knoting/mesh.h
@@ -45,8 +45,21 @@ class Mesh : public Asset {
     void load_mesh(const std::string& localTexturePath);
     void create_cube();
 
-    const bgfx::VertexBufferHandle get_vertex_buffer() { return m_vbh; }
-    const bgfx::IndexBufferHandle get_index_buffer() { return m_ibh; }
+    bgfx::VertexBufferHandle* get_vertex_buffer() {
+        p_vbh = &m_vbh;
+        return p_vbh;
+    }
+    bgfx::IndexBufferHandle* get_index_buffer() {
+        p_ibh = &m_ibh;
+        return p_ibh;
+    }
+
+    void set_vertex_buffer(bgfx::VertexBufferHandle vbh) {
+        m_vbh = vbh;
+    };
+    void set_index_buffer(bgfx::IndexBufferHandle ibh) {
+        m_ibh = ibh;
+    };
 
    private:
     bool internal_load_obj(const std::string& path);
@@ -61,6 +74,9 @@ class Mesh : public Asset {
    private:
     bgfx::VertexBufferHandle m_vbh;
     bgfx::IndexBufferHandle m_ibh;
+
+    bgfx::VertexBufferHandle* p_vbh;
+    bgfx::IndexBufferHandle* p_ibh;
 };
 
 class IndexBuffer {

--- a/core/inc/knoting/mesh.h
+++ b/core/inc/knoting/mesh.h
@@ -21,6 +21,18 @@ class VertexLayout;
 namespace knot {
 namespace components {
 
+struct Vertex {
+    glm::vec3 position;
+    glm::vec3 normal;
+    glm::vec2 texCoords;
+    glm::vec4 tangents;
+};
+
+struct VertexData {
+    std::vector<Vertex> vData;
+    std::vector<uint32_t> indices;
+};
+
 class Mesh : public Asset {
    public:
     Mesh();
@@ -41,6 +53,11 @@ class Mesh : public Asset {
     const bgfx::IndexBufferHandle get_index_buffer() { return m_ibh; }
 
    private:
+    bool internal_load_obj(const std::string& path);
+    bool internal_tiny_obj(const std::string& path);
+   private:
+    std::vector<Vertex> mVertices;
+
     std::vector<VertexLayout> m_vertexLayout;
     std::shared_ptr<IndexBuffer> m_indexBuffer;
 
@@ -51,12 +68,12 @@ class Mesh : public Asset {
 
 class IndexBuffer {
    public:
-    void set_index_buffer(const std::vector<uint16_t>& in_indices) { m_indices = in_indices; }
+    void set_index_buffer(const std::vector<int16_t>& in_indices) { m_indices = in_indices; }
     size_t get_memory_size() { return sizeof(m_indices[0]) * m_indices.size(); }
-    uint16_t& get_index_start() { return m_indices[0]; }
+    int16_t& get_index_start() { return m_indices[0]; }
 
    private:
-    std::vector<uint16_t> m_indices;
+    std::vector<int16_t> m_indices;
 };
 
 inline uint32_t encode_normal_rgba8(float _x, float _y = 0.0f, float _z = 0.0f, float _w = 0.0f) {

--- a/core/inc/knoting/mesh.h
+++ b/core/inc/knoting/mesh.h
@@ -15,23 +15,19 @@ namespace knot {
 namespace components {
 class IndexBuffer;
 class VertexLayout;
-}  // namespace components
-}  // namespace knot
-
-namespace knot {
-namespace components {
-
-struct Vertex {
+class Vertex {
+   public:
     glm::vec3 position;
     glm::vec3 normal;
     glm::vec2 texCoords;
     glm::vec4 tangents;
 };
 
-struct VertexData {
-    std::vector<Vertex> vData;
-    std::vector<uint32_t> indices;
-};
+}  // namespace components
+}  // namespace knot
+
+namespace knot {
+namespace components {
 
 class Mesh : public Asset {
    public:
@@ -55,6 +51,7 @@ class Mesh : public Asset {
    private:
     bool internal_load_obj(const std::string& path);
     bool internal_tiny_obj(const std::string& path);
+
    private:
     std::vector<Vertex> mVertices;
 
@@ -96,15 +93,15 @@ class VertexLayout {
     float m_z;
     uint32_t m_normal;
     uint32_t m_tangent;
-    int16_t m_u;
-    int16_t m_v;
+    float m_u;
+    float m_v;
 
     static void init() {
         s_meshVertexLayout.begin()
             .add(bgfx::Attrib::Position, 3, bgfx::AttribType::Float)
             .add(bgfx::Attrib::Normal, 4, bgfx::AttribType::Uint8, true, true)
             .add(bgfx::Attrib::Tangent, 4, bgfx::AttribType::Uint8, true, true)
-            .add(bgfx::Attrib::TexCoord0, 2, bgfx::AttribType::Int16, true, true)
+            .add(bgfx::Attrib::TexCoord0, 2, bgfx::AttribType::Float, true, true)
             .end();
 
         // TODO when animations are impl

--- a/core/inc/knoting/mesh.h
+++ b/core/inc/knoting/mesh.h
@@ -15,14 +15,6 @@ namespace knot {
 namespace components {
 class IndexBuffer;
 class VertexLayout;
-class Vertex {
-   public:
-    glm::vec3 position;
-    glm::vec3 normal;
-    glm::vec2 texCoords;
-    glm::vec4 tangents;
-};
-
 }  // namespace components
 }  // namespace knot
 
@@ -51,8 +43,6 @@ class Mesh : public Asset {
     bool internal_load_obj(const std::string& path);
 
    private:
-    std::vector<Vertex> mVertices;
-
     std::vector<VertexLayout> m_vertexLayout;
     std::shared_ptr<IndexBuffer> m_indexBuffer;
 

--- a/core/inc/knoting/mesh.h
+++ b/core/inc/knoting/mesh.h
@@ -36,8 +36,8 @@ class Mesh : public Asset {
     ~Mesh();
 
     //=For ECS========
-    void on_awake();
-    void on_destroy();
+    void on_awake() override;
+    void on_destroy() override;
     //=For Asset=======
     void generate_default_asset() override;
     //=================
@@ -65,12 +65,12 @@ class Mesh : public Asset {
 
 class IndexBuffer {
    public:
-    void set_index_buffer(const std::vector<int16_t>& in_indices) { m_indices = in_indices; }
+    void set_index_buffer(const std::vector<unsigned int>& in_indices) { m_indices = in_indices; }
     size_t get_memory_size() { return sizeof(m_indices[0]) * m_indices.size(); }
-    int16_t& get_index_start() { return m_indices[0]; }
+    unsigned int& get_index_start() { return m_indices[0]; }
 
    private:
-    std::vector<int16_t> m_indices;
+    std::vector<unsigned int> m_indices;
 };
 
 inline uint32_t encode_normal_rgba8(float _x, float _y = 0.0f, float _z = 0.0f, float _w = 0.0f) {

--- a/core/inc/knoting/mesh.h
+++ b/core/inc/knoting/mesh.h
@@ -31,6 +31,7 @@ class Mesh : public Asset {
     void on_awake();
     void on_destroy();
     //================
+    void generate_default_asset() override;
 
     void load_mesh(const std::string& localTexturePath);
     void create_cube();

--- a/core/inc/knoting/mesh.h
+++ b/core/inc/knoting/mesh.h
@@ -41,10 +41,12 @@ class Mesh : public Asset {
 
    private:
     bool internal_load_obj(const std::string& path);
+    std::vector<std::string> split(std::string s, std::string t);
 
    private:
     std::vector<VertexLayout> m_vertexLayout;
     std::shared_ptr<IndexBuffer> m_indexBuffer;
+    std::vector<std::string> m_splitResult;
 
    private:
     bgfx::VertexBufferHandle m_vbh;

--- a/core/inc/knoting/mesh.h
+++ b/core/inc/knoting/mesh.h
@@ -2,15 +2,13 @@
 
 #include <bgfx/bgfx.h>
 #include <bx/pixelformat.h>
-
+#include <knoting/asset.h>
 #include <knoting/types.h>
 #include <string>
 #include <vector>
 
 // TODO Add const variables headers
-constexpr char PATH_SHADER[] = "../res/shaders/";
-constexpr char PATH_TEXTURE[] = "../res/textures/";
-constexpr char PATH_MODELS[] = "../res/models/";
+
 // end TODO
 
 namespace knot {
@@ -23,9 +21,10 @@ class VertexLayout;
 namespace knot {
 namespace components {
 
-class Mesh {
+class Mesh : public Asset{
    public:
     Mesh();
+    Mesh(const std::string& path);
     ~Mesh();
 
     //=For ECS========

--- a/core/inc/knoting/mesh.h
+++ b/core/inc/knoting/mesh.h
@@ -21,7 +21,7 @@ class VertexLayout;
 namespace knot {
 namespace components {
 
-class Mesh : public Asset{
+class Mesh : public Asset {
    public:
     Mesh();
     Mesh(const std::string& path);

--- a/core/inc/knoting/mesh.h
+++ b/core/inc/knoting/mesh.h
@@ -41,7 +41,7 @@ class Mesh : public Asset {
 
    private:
     bool internal_load_obj(const std::string& path);
-    std::vector<std::string> split(std::string s, std::string t);
+    std::vector<std::string> split(std::string s, const std::string& t);
 
    private:
     std::vector<VertexLayout> m_vertexLayout;

--- a/core/inc/knoting/mesh.h
+++ b/core/inc/knoting/mesh.h
@@ -42,28 +42,13 @@ class Mesh : public Asset {
     void generate_default_asset() override;
     //=================
 
-    void load_mesh(const std::string& localTexturePath);
     void create_cube();
 
-    bgfx::VertexBufferHandle* get_vertex_buffer() {
-        p_vbh = &m_vbh;
-        return p_vbh;
-    }
-    bgfx::IndexBufferHandle* get_index_buffer() {
-        p_ibh = &m_ibh;
-        return p_ibh;
-    }
-
-    void set_vertex_buffer(bgfx::VertexBufferHandle vbh) {
-        m_vbh = vbh;
-    };
-    void set_index_buffer(bgfx::IndexBufferHandle ibh) {
-        m_ibh = ibh;
-    };
+    bgfx::VertexBufferHandle get_vertex_buffer() { return m_vbh; }
+    bgfx::IndexBufferHandle get_index_buffer() { return m_ibh; }
 
    private:
     bool internal_load_obj(const std::string& path);
-    bool internal_tiny_obj(const std::string& path);
 
    private:
     std::vector<Vertex> mVertices;
@@ -74,9 +59,6 @@ class Mesh : public Asset {
    private:
     bgfx::VertexBufferHandle m_vbh;
     bgfx::IndexBufferHandle m_ibh;
-
-    bgfx::VertexBufferHandle* p_vbh;
-    bgfx::IndexBufferHandle* p_ibh;
 };
 
 class IndexBuffer {

--- a/core/inc/knoting/mesh.h
+++ b/core/inc/knoting/mesh.h
@@ -30,8 +30,9 @@ class Mesh : public Asset {
     //=For ECS========
     void on_awake();
     void on_destroy();
-    //================
+    //=For Asset=======
     void generate_default_asset() override;
+    //=================
 
     void load_mesh(const std::string& localTexturePath);
     void create_cube();

--- a/core/inc/knoting/shader_program.h
+++ b/core/inc/knoting/shader_program.h
@@ -17,6 +17,7 @@ class ShaderProgram : public Asset {
     void on_awake();
     void on_destroy();
     //================
+    void generate_default_asset() override;
 
     bool load_shader(const std::string& folderName,
                      const std::string& vertexShaderPath,

--- a/core/inc/knoting/shader_program.h
+++ b/core/inc/knoting/shader_program.h
@@ -2,12 +2,15 @@
 
 #include <bgfx/bgfx.h>
 #include <string>
+#include <knoting/asset.h>
 
 namespace knot {
 namespace components {
-class ShaderProgram {
+class ShaderProgram : public Asset{
    public:
     ShaderProgram();
+    ShaderProgram(const std::string& path);
+
     ~ShaderProgram();
 
     //=For ECS========

--- a/core/inc/knoting/shader_program.h
+++ b/core/inc/knoting/shader_program.h
@@ -14,8 +14,8 @@ class ShaderProgram : public Asset {
     ~ShaderProgram();
 
     //=For ECS========
-    void on_awake();
-    void on_destroy();
+    void on_awake() override;
+    void on_destroy() override;
     //=For Asset=======
     void generate_default_asset() override;
     //=================

--- a/core/inc/knoting/shader_program.h
+++ b/core/inc/knoting/shader_program.h
@@ -1,12 +1,12 @@
 #pragma once
 
 #include <bgfx/bgfx.h>
-#include <string>
 #include <knoting/asset.h>
+#include <string>
 
 namespace knot {
 namespace components {
-class ShaderProgram : public Asset{
+class ShaderProgram : public Asset {
    public:
     ShaderProgram();
     ShaderProgram(const std::string& path);

--- a/core/inc/knoting/shader_program.h
+++ b/core/inc/knoting/shader_program.h
@@ -16,8 +16,9 @@ class ShaderProgram : public Asset {
     //=For ECS========
     void on_awake();
     void on_destroy();
-    //================
+    //=For Asset=======
     void generate_default_asset() override;
+    //=================
 
     bool load_shader(const std::string& folderName,
                      const std::string& vertexShaderPath,

--- a/core/inc/knoting/spot_light.h
+++ b/core/inc/knoting/spot_light.h
@@ -1,0 +1,30 @@
+#pragma once
+#include <knoting/types.h>
+
+namespace knot {
+namespace components {
+class SpotLight {
+   public:
+    SpotLight();
+    ~SpotLight();
+
+    //=For ECS========
+    void on_awake();
+    void on_destroy();
+    //================
+
+    float get_outer_radius() { return m_lightOuterRadius; };
+    float get_inner_radius() { return m_lightInnerRadius; };
+    vec3 get_color() { return m_color; };
+
+    void set_outer_radius(float lightOuterRadius) { m_lightOuterRadius = lightOuterRadius; };
+    void set_inner_radius(float lightInnerRadius) { m_lightInnerRadius = lightInnerRadius; };
+    void set_color(vec3 color) { m_color = color; };
+
+   private:
+    float m_lightOuterRadius = 1.0f;
+    float m_lightInnerRadius = 0.5f;
+    vec3 m_color = vec3(3.0f);
+};
+}  // namespace components
+}  // namespace knot

--- a/core/inc/knoting/texture.h
+++ b/core/inc/knoting/texture.h
@@ -20,11 +20,13 @@ class Texture : public Asset {
     //=For ECS========
     void on_awake();
     void on_destroy();
-    //================
+    //=For Asset=======
     void generate_default_asset() override;
-    void generate_solid_color_texture(const vec4& color, const std::string& name);
+    //=================
 
+    void generate_solid_color_texture(const vec4& color, const std::string& name);
     void load_texture_2d(const std::string& path, bool usingMipMaps = true, bool usingAnisotropicFiltering = true);
+
     bgfx::TextureHandle get_texture_handle() { return m_textureHandle; }
 
    private:
@@ -32,7 +34,6 @@ class Texture : public Asset {
 
    private:
     bgfx::TextureHandle m_textureHandle;
-
     uint16_t width = 0;
     uint16_t height = 0;
 };

--- a/core/inc/knoting/texture.h
+++ b/core/inc/knoting/texture.h
@@ -21,12 +21,14 @@ class Texture : public Asset {
     void on_awake();
     void on_destroy();
     //================
-    void generate_default_asset();
+    void generate_default_asset() override;
+    void generate_solid_color_texture(const vec4& color, const std::string& name);
 
     void load_texture_2d(const std::string& path, bool usingMipMaps = true, bool usingAnisotropicFiltering = true);
-    bgfx::TextureHandle generate_solid_texture(const vec4& color, const std::string& name);
-
     bgfx::TextureHandle get_texture_handle() { return m_textureHandle; }
+
+   private:
+    bgfx::TextureHandle internal_generate_solid_texture(const vec4& color, const std::string& name);
 
    private:
     bgfx::TextureHandle m_textureHandle;

--- a/core/inc/knoting/texture.h
+++ b/core/inc/knoting/texture.h
@@ -21,8 +21,10 @@ class Texture : public Asset {
     void on_awake();
     void on_destroy();
     //================
+    void generate_default_asset();
 
     void load_texture_2d(const std::string& path, bool usingMipMaps = true, bool usingAnisotropicFiltering = true);
+    bgfx::TextureHandle generate_solid_texture(const vec4& color, const std::string& name);
 
     bgfx::TextureHandle get_texture_handle() { return m_textureHandle; }
 

--- a/core/inc/knoting/texture.h
+++ b/core/inc/knoting/texture.h
@@ -3,6 +3,7 @@
 #include <bgfx/bgfx.h>
 #include <bimg/bimg.h>
 #include <bimg/decode.h>
+#include <knoting/asset.h>
 #include <knoting/types.h>
 #include <filesystem>
 #include <string>
@@ -10,9 +11,10 @@
 namespace knot {
 namespace components {
 
-class Texture {
+class Texture : public Asset {
    public:
     Texture();
+    Texture(const std::string& path);
     ~Texture();
 
     //=For ECS========
@@ -29,7 +31,6 @@ class Texture {
 
     uint16_t width = 0;
     uint16_t height = 0;
-    static constexpr char PATH_TEXTURE[] = "../res/textures/";
 };
 
 }  // namespace components

--- a/core/inc/knoting/texture.h
+++ b/core/inc/knoting/texture.h
@@ -18,8 +18,8 @@ class Texture : public Asset {
     ~Texture();
 
     //=For ECS========
-    void on_awake();
-    void on_destroy();
+    void on_awake() override;
+    void on_destroy() override;
     //=For Asset=======
     void generate_default_asset() override;
     //=================

--- a/core/inc/knoting/types.h
+++ b/core/inc/knoting/types.h
@@ -12,6 +12,11 @@
 #include <nlohmann/json.hpp>
 
 namespace knot {
+namespace asset {
+
+enum class AssetType { UNKNOWN, TEXTURE, MESH, SHADER, CUBEMAP };
+
+}
 
 using namespace glm;
 using namespace uuids;

--- a/core/inc/knoting/types.h
+++ b/core/inc/knoting/types.h
@@ -16,7 +16,9 @@ namespace asset {
 
 enum class AssetType { UNKNOWN, TEXTURE, MESH, SHADER, CUBEMAP };
 
-}
+enum class TextureType { Albedo, Normal, Metallic, Roughness, Occlusion, LAST };
+
+}  // namespace asset
 
 using namespace glm;
 using namespace uuids;

--- a/core/inc/knoting/types.h
+++ b/core/inc/knoting/types.h
@@ -14,6 +14,7 @@
 namespace knot {
 namespace asset {
 
+enum class AssetState { IDLE, LOADING, FINISHED, FAILED };
 enum class AssetType { UNKNOWN, TEXTURE, MESH, SHADER, CUBEMAP };
 
 enum class TextureType { Albedo, Normal, Metallic, Roughness, Occlusion, LAST };

--- a/core/inc/knoting/types.h
+++ b/core/inc/knoting/types.h
@@ -39,12 +39,16 @@ using vec4d = vec<4, f64>;
         x = f.x;                  \
         y = f.y;                  \
     }                             \
-    operator knot::vec2() const { return knot::vec2(x, y); }
-#define IM_VEC4_CLASS_EXTRA       \
-    ImVec4(const knot::vec4& f) { \
-        x = f.x;                  \
-        y = f.y;                  \
-        z = f.z;                  \
-        w = f.w;                  \
-    }                             \
-    operator knot::vec4() const { return knot::vec4(x, y, z, w); }
+    operator knot::vec2() const { \
+        return knot::vec2(x, y);  \
+    }
+#define IM_VEC4_CLASS_EXTRA            \
+    ImVec4(const knot::vec4& f) {      \
+        x = f.x;                       \
+        y = f.y;                       \
+        z = f.z;                       \
+        w = f.w;                       \
+    }                                  \
+    operator knot::vec4() const {      \
+        return knot::vec4(x, y, z, w); \
+    }

--- a/core/inc/knoting/types.h
+++ b/core/inc/knoting/types.h
@@ -14,9 +14,8 @@
 namespace knot {
 namespace asset {
 
-enum class AssetState { IDLE, LOADING, FINISHED, FAILED };
-enum class AssetType { UNKNOWN, TEXTURE, MESH, SHADER, CUBEMAP };
-
+enum class AssetState { Idle, Loading, Finished, Failed, LAST };
+enum class AssetType { Unknown, Texture, Mesh, Shader, Cubemap, LAST };
 enum class TextureType { Albedo, Normal, Metallic, Roughness, Occlusion, LAST };
 
 }  // namespace asset

--- a/core/inc/knoting/types.h
+++ b/core/inc/knoting/types.h
@@ -39,16 +39,12 @@ using vec4d = vec<4, f64>;
         x = f.x;                  \
         y = f.y;                  \
     }                             \
-    operator knot::vec2() const { \
-        return knot::vec2(x, y);  \
-    }
-#define IM_VEC4_CLASS_EXTRA            \
-    ImVec4(const knot::vec4& f) {      \
-        x = f.x;                       \
-        y = f.y;                       \
-        z = f.z;                       \
-        w = f.w;                       \
-    }                                  \
-    operator knot::vec4() const {      \
-        return knot::vec4(x, y, z, w); \
-    }
+    operator knot::vec2() const { return knot::vec2(x, y); }
+#define IM_VEC4_CLASS_EXTRA       \
+    ImVec4(const knot::vec4& f) { \
+        x = f.x;                  \
+        y = f.y;                  \
+        z = f.z;                  \
+        w = f.w;                  \
+    }                             \
+    operator knot::vec4() const { return knot::vec4(x, y, z, w); }

--- a/core/src/asset.cpp
+++ b/core/src/asset.cpp
@@ -1,0 +1,16 @@
+#include <knoting/asset.h>
+
+#include <knoting/asset_loaders/image_loader.h>
+#include <knoting/asset_loaders/model_loader.h>
+#include <filesystem>
+
+#include <knoting/log.h>
+
+namespace knot {
+
+Asset::Asset(AssetType assetType, const std::string& path) : m_assetType(assetType) {
+    m_fullPath = path;
+    m_assetName = std::filesystem::path(m_fullPath).filename().string();
+    m_assetDirectory = std::filesystem::path(m_fullPath).parent_path().string();
+}
+}  // namespace knot

--- a/core/src/asset.cpp
+++ b/core/src/asset.cpp
@@ -8,7 +8,8 @@
 
 namespace knot {
 
-Asset::Asset(AssetType assetType, const std::string& path) : m_assetType(assetType) {
+Asset::Asset(AssetType assetType, const std::string& path, const std::string& fallbackName) : m_assetType(assetType) {
+    m_fallbackName = fallbackName;
     m_fullPath = path;
     m_assetName = std::filesystem::path(m_fullPath).filename().string();
     m_assetDirectory = std::filesystem::path(m_fullPath).parent_path().string();

--- a/core/src/asset.cpp
+++ b/core/src/asset.cpp
@@ -8,10 +8,26 @@
 
 namespace knot {
 
-Asset::Asset(AssetType assetType, const std::string& path, const std::string& fallbackName) : m_assetType(assetType) {
-    m_fallbackName = fallbackName;
+Asset::Asset(AssetType assetType, const std::string& path) : m_assetType(assetType) {
+    set_fallback_name(assetType);
     m_fullPath = path;
     m_assetName = std::filesystem::path(m_fullPath).filename().string();
     m_assetDirectory = std::filesystem::path(m_fullPath).parent_path().string();
+}
+void Asset::set_fallback_name(AssetType type) {
+    switch (type) {
+        case AssetType::Texture:
+            m_fallbackName = fallbackTextureName;
+            break;
+        case AssetType::Mesh:
+            m_fallbackName = fallbackMeshName;
+            break;
+        case AssetType::Shader:
+            m_fallbackName = fallbackShaderName;
+            break;
+        case AssetType::Cubemap:
+            m_fallbackName = fallbackCubeMapName;
+            break;
+    }
 }
 }  // namespace knot

--- a/core/src/asset_manager.cpp
+++ b/core/src/asset_manager.cpp
@@ -21,8 +21,14 @@ void AssetManager::on_destroy() {
 
 void AssetManager::load_assets_manual() {
     // FALLBACK TEXTURE
-    m_assets.insert({"fallbackTexture", std::make_shared<components::Texture>()});
-    std::static_pointer_cast<components::Texture>(m_assets["fallbackTexture"])->generate_default_asset();
+    const std::string fb_tex = "fallbackTexture";
+    m_assets.insert({fb_tex, std::make_shared<components::Texture>()});
+    std::static_pointer_cast<components::Texture>(m_assets[fb_tex])->generate_default_asset();
+    // SOLID COLOR TEXTURES
+    const std::string white_tex = "whiteTexture";
+    m_assets.insert({white_tex, std::make_shared<components::Texture>()});
+    std::static_pointer_cast<components::Texture>(m_assets[white_tex])
+        ->generate_solid_color_texture(vec4(1), white_tex);
     // FALLBACK MESH
     // FALLBACK SHADER
     // FROM FILE

--- a/core/src/asset_manager.cpp
+++ b/core/src/asset_manager.cpp
@@ -35,11 +35,12 @@ void AssetManager::load_assets_manual() {
     m_assets.insert({fb_msh, std::make_shared<components::Mesh>()});
     std::static_pointer_cast<components::Texture>(m_assets[fb_msh])->generate_default_asset();
 
-    // FALLBACK SHADER
     // FROM FILE
     AssetManager::load_asset<components::Texture>("UV_Grid_test.png");
     AssetManager::load_asset<components::Texture>("normal_tiles_1k.png");
+
     AssetManager::load_asset<components::Mesh>("uv_cube.obj");
+    AssetManager::load_asset<components::Mesh>("dragon.obj");
 
     for (auto as : m_assets) {
         log::debug("asset loaded manual : {}", as.first);

--- a/core/src/asset_manager.cpp
+++ b/core/src/asset_manager.cpp
@@ -3,48 +3,40 @@
 namespace knot {
 
 void AssetManager::on_awake() {
-    log::warn("ON AWAKE");
     s_assetManager = std::ref(*this);
-    // TODO LOAD ALL ASSETS IN "ASSET/RESOURCE" FOLDER
-    // MANUALLY LOAD FOR NOW
+    // TODO LOAD ALL ASSETS IN "ASSET/RES" FOLDER
     load_assets_manual();
-
     load_assets_serialize();
 }
 void AssetManager::on_destroy() {
     for (auto it = m_assets.begin(); it != m_assets.end(); ++it) {
         it->second->on_destroy();
     }
-
-    log::info("ASSET MANAGER HAS BEEN DESTROYED");
+    log::info("AssetManager destroyed");
 }
 
 void AssetManager::load_assets_manual() {
-    // FALLBACK TEXTURE
+    //=Gen Textures===
     const std::string fb_tex = "fallbackTexture";
     m_assets.insert({fb_tex, std::make_shared<components::Texture>()});
     std::static_pointer_cast<components::Texture>(m_assets[fb_tex])->generate_default_asset();
-    // SOLID COLOR TEXTURES
+
     const std::string white_tex = "whiteTexture";
     m_assets.insert({white_tex, std::make_shared<components::Texture>()});
     std::static_pointer_cast<components::Texture>(m_assets[white_tex])
         ->generate_solid_color_texture(vec4(1), white_tex);
 
-    // FALLBACK MESH
+    //=Gen Meshes=====
     const std::string fb_msh = "fallbackMesh";
     m_assets.insert({fb_msh, std::make_shared<components::Mesh>()});
     std::static_pointer_cast<components::Texture>(m_assets[fb_msh])->generate_default_asset();
 
-    // FROM FILE
+    //=From File======
     AssetManager::load_asset<components::Texture>("UV_Grid_test.png");
     AssetManager::load_asset<components::Texture>("normal_tiles_1k.png");
 
     AssetManager::load_asset<components::Mesh>("uv_cube.obj");
     AssetManager::load_asset<components::Mesh>("dragon.obj");
-
-    for (auto as : m_assets) {
-        log::debug("asset loaded manual : {}", as.first);
-    }
 }
 
 void AssetManager::load_assets_serialize() {}

--- a/core/src/asset_manager.cpp
+++ b/core/src/asset_manager.cpp
@@ -3,6 +3,7 @@
 namespace knot {
 
 void AssetManager::on_awake() {
+    log::warn("ON AWAKE");
     s_assetManager = std::ref(*this);
     // TODO LOAD ALL ASSETS IN "ASSET/RESOURCE" FOLDER
     // MANUALLY LOAD FOR NOW
@@ -11,22 +12,25 @@ void AssetManager::on_awake() {
     load_assets_serialize();
 }
 void AssetManager::on_destroy() {
-    Subsystem::on_destroy();
+    log::warn("ASSET MANAGER HAS BEEN DESTROYED");
 }
 
 void AssetManager::load_assets_manual() {
-    auto assetManager = get_asset_manager()->get();
-
-    {
-        auto alb = assetManager.load_asset<components::Texture>("UV_Grid_test.png").lock();
-        auto nrm = assetManager.load_asset<components::Texture>("normal_tiles_1k.png").lock();
-    }
-    {
-        auto alb = assetManager.load_asset<components::Texture>("UV_Grid_test.png").lock();
-        auto nrm = assetManager.load_asset<components::Texture>("normal_tiles_1k.png").lock();
-    }
 }
 
-void AssetManager::load_assets_serialize() {}
+void AssetManager::load_assets_serialize() {
+}
+void AssetManager::on_update(double m_delta_time) {
+
+    auto alb = AssetManager::load_asset<components::Texture>("UV_Grid_test.png").lock();
+    auto nrm = AssetManager::load_asset<components::Texture>("normal_tiles_1k.png").lock();
+
+    auto alb_2 = AssetManager::load_asset<components::Texture>("UV_Grid_test.png").lock();
+    auto nrm_2 = AssetManager::load_asset<components::Texture>("normal_tiles_1k.png").lock();
+
+    log::debug("ASSET CACHE SIZE");
+    log::debug(m_assets.size());
+    log::debug("-----------------------");
+}
 
 }  // namespace knot

--- a/core/src/asset_manager.cpp
+++ b/core/src/asset_manager.cpp
@@ -1,0 +1,30 @@
+#include <knoting/asset_manager.h>
+#include <knoting/camera.h>
+
+namespace knot {
+
+void AssetManager::on_awake() {
+    // TODO LOAD ALL ASSETS IN "ASSET/RESOURCE" FOLDER
+    // MANUALLY LOAD FOR NOW
+    load_assets_manual();
+
+    load_assets_serialize();
+}
+void AssetManager::on_destroy() {
+    Subsystem::on_destroy();
+}
+
+void AssetManager::load_assets_manual() {
+    {
+        auto alb = load_asset<components::Texture>("UV_Grid_test.png").lock();
+        auto nrm = load_asset<components::Texture>("normal_tiles_1k.png").lock();
+    }
+    {
+        auto alb = load_asset<components::Texture>("UV_Grid_test.png").lock();
+        auto nrm = load_asset<components::Texture>("normal_tiles_1k.png").lock();
+    }
+}
+
+void AssetManager::load_assets_serialize() {}
+
+}  // namespace knot

--- a/core/src/asset_manager.cpp
+++ b/core/src/asset_manager.cpp
@@ -12,25 +12,17 @@ void AssetManager::on_awake() {
     load_assets_serialize();
 }
 void AssetManager::on_destroy() {
-    log::warn("ASSET MANAGER HAS BEEN DESTROYED");
+    for (auto it = m_assets.begin(); it != m_assets.end(); ++it) {
+        it->second->on_destroy();
+    }
+
+    log::info("ASSET MANAGER HAS BEEN DESTROYED");
 }
 
 void AssetManager::load_assets_manual() {
+    AssetManager::load_asset<components::Texture>("UV_Grid_test.png");
+    AssetManager::load_asset<components::Texture>("normal_tiles_1k.png");
 }
 
-void AssetManager::load_assets_serialize() {
-}
-void AssetManager::on_update(double m_delta_time) {
-
-    auto alb = AssetManager::load_asset<components::Texture>("UV_Grid_test.png").lock();
-    auto nrm = AssetManager::load_asset<components::Texture>("normal_tiles_1k.png").lock();
-
-    auto alb_2 = AssetManager::load_asset<components::Texture>("UV_Grid_test.png").lock();
-    auto nrm_2 = AssetManager::load_asset<components::Texture>("normal_tiles_1k.png").lock();
-
-    log::debug("ASSET CACHE SIZE");
-    log::debug(m_assets.size());
-    log::debug("-----------------------");
-}
-
+void AssetManager::load_assets_serialize() {}
 }  // namespace knot

--- a/core/src/asset_manager.cpp
+++ b/core/src/asset_manager.cpp
@@ -20,6 +20,10 @@ void AssetManager::on_destroy() {
 }
 
 void AssetManager::load_assets_manual() {
+    //FALLBACK
+    m_assets.insert({"fallbackTexture", std::make_shared<components::Texture>()});
+    std::static_pointer_cast<components::Texture>(m_assets["fallbackTexture"])->generate_default_asset();
+    //FROM FILE
     AssetManager::load_asset<components::Texture>("UV_Grid_test.png");
     AssetManager::load_asset<components::Texture>("normal_tiles_1k.png");
 }

--- a/core/src/asset_manager.cpp
+++ b/core/src/asset_manager.cpp
@@ -20,10 +20,12 @@ void AssetManager::on_destroy() {
 }
 
 void AssetManager::load_assets_manual() {
-    //FALLBACK
+    // FALLBACK TEXTURE
     m_assets.insert({"fallbackTexture", std::make_shared<components::Texture>()});
     std::static_pointer_cast<components::Texture>(m_assets["fallbackTexture"])->generate_default_asset();
-    //FROM FILE
+    // FALLBACK MESH
+    // FALLBACK SHADER
+    // FROM FILE
     AssetManager::load_asset<components::Texture>("UV_Grid_test.png");
     AssetManager::load_asset<components::Texture>("normal_tiles_1k.png");
 }

--- a/core/src/asset_manager.cpp
+++ b/core/src/asset_manager.cpp
@@ -29,11 +29,21 @@ void AssetManager::load_assets_manual() {
     m_assets.insert({white_tex, std::make_shared<components::Texture>()});
     std::static_pointer_cast<components::Texture>(m_assets[white_tex])
         ->generate_solid_color_texture(vec4(1), white_tex);
+
     // FALLBACK MESH
+    const std::string fb_msh = "fallbackMesh";
+    m_assets.insert({fb_msh, std::make_shared<components::Mesh>()});
+    std::static_pointer_cast<components::Texture>(m_assets[fb_msh])->generate_default_asset();
+
     // FALLBACK SHADER
     // FROM FILE
     AssetManager::load_asset<components::Texture>("UV_Grid_test.png");
     AssetManager::load_asset<components::Texture>("normal_tiles_1k.png");
+    AssetManager::load_asset<components::Mesh>("uv_cube.obj");
+
+    for (auto as : m_assets) {
+        log::debug("asset loaded manual : {}", as.first);
+    }
 }
 
 void AssetManager::load_assets_serialize() {}

--- a/core/src/asset_manager.cpp
+++ b/core/src/asset_manager.cpp
@@ -1,9 +1,9 @@
 #include <knoting/asset_manager.h>
-#include <knoting/camera.h>
 
 namespace knot {
 
 void AssetManager::on_awake() {
+    s_assetManager = std::ref(*this);
     // TODO LOAD ALL ASSETS IN "ASSET/RESOURCE" FOLDER
     // MANUALLY LOAD FOR NOW
     load_assets_manual();
@@ -15,13 +15,15 @@ void AssetManager::on_destroy() {
 }
 
 void AssetManager::load_assets_manual() {
+    auto assetManager = get_asset_manager()->get();
+
     {
-        auto alb = load_asset<components::Texture>("UV_Grid_test.png").lock();
-        auto nrm = load_asset<components::Texture>("normal_tiles_1k.png").lock();
+        auto alb = assetManager.load_asset<components::Texture>("UV_Grid_test.png").lock();
+        auto nrm = assetManager.load_asset<components::Texture>("normal_tiles_1k.png").lock();
     }
     {
-        auto alb = load_asset<components::Texture>("UV_Grid_test.png").lock();
-        auto nrm = load_asset<components::Texture>("normal_tiles_1k.png").lock();
+        auto alb = assetManager.load_asset<components::Texture>("UV_Grid_test.png").lock();
+        auto nrm = assetManager.load_asset<components::Texture>("normal_tiles_1k.png").lock();
     }
 }
 

--- a/core/src/engine.cpp
+++ b/core/src/engine.cpp
@@ -42,8 +42,7 @@ void Engine::update_modules() {
     // 6) SYSTEM : Sorted Transparent Render Pass
     // 7) SYSTEM : Post Processing Stack
 
-    //    m_forwardRenderModule->on_render();
-    m_forwardRenderModule->render_pbr();
+    m_forwardRenderModule->on_render();
     m_forwardRenderModule->on_post_render();
 
     for (auto& module : m_engineModules) {

--- a/core/src/engine.cpp
+++ b/core/src/engine.cpp
@@ -6,9 +6,11 @@ namespace knot {
 Engine::Engine() {
     m_windowModule = std::make_shared<knot::Window>(m_windowWidth, m_windowHeight, m_windowTitle, *this);
     m_forwardRenderModule = std::make_shared<knot::ForwardRenderer>(*this);
+    m_assetManager = std::make_shared<knot::AssetManager>();
 
     // order dependent
     m_engineModules.emplace_back(m_windowModule);
+    m_engineModules.emplace_back(m_assetManager);
     m_engineModules.emplace_back(m_forwardRenderModule);
 
     for (auto& module : m_engineModules) {

--- a/core/src/forward_renderer.cpp
+++ b/core/src/forward_renderer.cpp
@@ -38,9 +38,9 @@ void ForwardRenderer::render_pbr() {
         }
 
         GameObject go = goOpt.value();
-        Transform& transform = registry.get<Transform>(go.get_handle());
-        EditorCamera& editorCamera = registry.get<EditorCamera>(go.get_handle());
-        Name& name = registry.get<Name>(go.get_handle());
+        Transform& transform = go.get_component<Transform>();
+        EditorCamera& editorCamera = go.get_component<EditorCamera>();
+        Name& name = go.get_component<Name>();
 
         const glm::vec3 pos = transform.get_position();
         const glm::vec3 lookTarget = editorCamera.get_look_target();
@@ -71,10 +71,10 @@ void ForwardRenderer::render_pbr() {
         }
 
         GameObject go = goOpt.value();
-        Transform& transform = registry.get<Transform>(go.get_handle());
-        Mesh& mesh = registry.get<Mesh>(go.get_handle());
-        Material& material = registry.get<Material>(go.get_handle());
-        Name& name = registry.get<Name>(go.get_handle());
+        Transform& transform = go.get_component<Transform>();
+        Mesh& mesh = go.get_component<Mesh>();
+        Material& material = go.get_component<Material>();
+        Name& name = go.get_component<Name>();
 
         bgfx::setTransform(value_ptr(transform.get_model_matrix()));
 

--- a/core/src/forward_renderer.cpp
+++ b/core/src/forward_renderer.cpp
@@ -74,6 +74,10 @@ void ForwardRenderer::on_render() {
         lightPosRadius[ii][2] = -10.0f;
         lightPosRadius[ii][3] = 17.0f;
     }
+    log::info("light [{}], {}, {}, {}",0,lightPosRadius[0][0],lightPosRadius[0][1],lightPosRadius[0][2]);
+    log::info("light [{}], {}, {}, {}",1,lightPosRadius[1][0],lightPosRadius[1][1],lightPosRadius[1][2]);
+    log::info("light [{}], {}, {}, {}",3,lightPosRadius[3][0],lightPosRadius[3][1],lightPosRadius[3][2]);
+    log::info("light [{}], {}, {}, {}",2,lightPosRadius[2][0],lightPosRadius[2][1],lightPosRadius[2][2]);
 
     float lightRgbInnerR[4][4] = {
         {1.0f, 0.7f, 0.2f, 0.5f},

--- a/core/src/forward_renderer.cpp
+++ b/core/src/forward_renderer.cpp
@@ -21,7 +21,7 @@ ForwardRenderer::ForwardRenderer(Engine& engine) : m_engine(engine) {
     u_lightRgbInnerR = bgfx::createUniform("u_lightRgbInnerR", bgfx::UniformType::Vec4, m_numLights);
 }
 
-void ForwardRenderer::render_pbr() {
+void ForwardRenderer::on_render() {
     using namespace components;
     clear_framebuffer();
     bgfx::touch(0);
@@ -125,8 +125,6 @@ void ForwardRenderer::render_pbr() {
     bgfx::frame();
 }
 
-void ForwardRenderer::on_render() {}
-
 void ForwardRenderer::on_post_render() {}
 
 void ForwardRenderer::on_awake() {}
@@ -137,7 +135,10 @@ void ForwardRenderer::on_update(double m_delta_time) {
 
 void ForwardRenderer::on_late_update() {}
 
-void ForwardRenderer::on_destroy() {}
+void ForwardRenderer::on_destroy() {
+    bgfx::destroy(u_lightPosRadius);
+    bgfx::destroy(u_lightRgbInnerR);
+}
 
 void ForwardRenderer::recreate_framebuffer(uint16_t width, uint16_t height, uint16_t id) {
     bgfx::reset((uint32_t)width, (uint32_t)height, BGFX_RESET_VSYNC);

--- a/core/src/forward_renderer.cpp
+++ b/core/src/forward_renderer.cpp
@@ -14,7 +14,11 @@ namespace knot {
 
 ForwardRenderer::~ForwardRenderer() {}
 
-ForwardRenderer::ForwardRenderer(Engine& engine) : m_engine(engine) {}
+ForwardRenderer::ForwardRenderer(Engine& engine) : m_engine(engine) {
+    m_numLights = 4;
+    u_lightPosRadius = bgfx::createUniform("u_lightPosRadius", bgfx::UniformType::Vec4, m_numLights);
+    u_lightRgbInnerR = bgfx::createUniform("u_lightRgbInnerR", bgfx::UniformType::Vec4, m_numLights);
+}
 
 void ForwardRenderer::render_pbr() {
     using namespace components;
@@ -61,6 +65,23 @@ void ForwardRenderer::render_pbr() {
         }
     }
 
+    // TODO Replace With lights system
+    float lightPosRadius[4][4];
+    for (uint32_t ii = 0; ii < m_numLights; ++ii) {
+        lightPosRadius[ii][0] = glm::sin((0.4 * (0.4f + ii * 0.17f) + ii * glm::half_pi<float>() * 1.37f)) * 15.0f;
+        lightPosRadius[ii][1] = glm::cos((0.4f * (0.6f + ii * 0.29f) + ii * glm::half_pi<float>() * 1.49f)) * 15.0f;
+        lightPosRadius[ii][2] = -10.0f;
+        lightPosRadius[ii][3] = 17.0f;
+    }
+
+    float lightRgbInnerR[4][4] = {
+        {1.0f, 0.7f, 0.2f, 0.5f},
+        {0.7f, 0.2f, 1.0f, 0.5f},
+        {0.2f, 1.0f, 0.7f, 0.5f},
+        {1.0f, 0.4f, 0.2f, 0.5f},
+    };
+    // TODO end
+
     //=PBR PIPELINE===========================
 
     auto entities = registry.view<Transform, Mesh, Material, Name>();
@@ -76,11 +97,19 @@ void ForwardRenderer::render_pbr() {
         Material& material = go.get_component<Material>();
         Name& name = go.get_component<Name>();
 
+        // TODO get from lights Class
+        bgfx::setUniform(u_lightPosRadius, lightPosRadius, m_numLights);
+        bgfx::setUniform(u_lightRgbInnerR, lightRgbInnerR, m_numLights);
+        // TODO end
+
         bgfx::setTransform(value_ptr(transform.get_model_matrix()));
 
         // Set vertex and index buffer.
         bgfx::setVertexBuffer(0, mesh.get_vertex_buffer());
-        bgfx::setIndexBuffer(mesh.get_index_buffer());
+
+        if (isValid(mesh.get_index_buffer())) {
+            bgfx::setIndexBuffer(mesh.get_index_buffer());
+        }
 
         // Bind Uniforms & textures.
         material.set_uniforms();
@@ -94,75 +123,7 @@ void ForwardRenderer::render_pbr() {
     bgfx::frame();
 }
 
-void ForwardRenderer::on_render() {
-    // clear_framebuffer();
-
-    // bgfx::touch(0);
-
-    //
-    //    const glm::vec3 at = {0.0f, 0.0f, 0.0f};
-    //    const glm::vec3 eye = {0.0f, 0.0f, -7.0f};
-    //    const glm::vec3 up = {0.0f, 1.0f, 0.0f};
-    //
-    //    const float fovY = glm::radians(60.0f);
-    //    const float aspectRatio = float((float)get_window_width() / (float)get_window_height());
-    //    const float zNear = 0.1f;
-    //    const float zFar = 100.0f;
-    //
-    //    // Set view and projection matrix for view 0.
-    //    {
-    //        glm::mat4 view;
-    //        view = glm::lookAt(eye, at, up);
-    //        glm::mat4 proj = glm::perspective(fovY, aspectRatio, zNear, zFar);
-    //
-    //        bgfx::setViewTransform(0, &view[0][0], &proj[0][0]);
-    //    }
-    //
-    //    float lightPosRadius[4][4];
-    //    for (uint32_t ii = 0; ii < m_numLights; ++ii) {
-    //        lightPosRadius[ii][0] =
-    //            glm::sin((m_timePassed * (0.1f + ii * 0.17f) + ii * glm::half_pi<float>() * 1.37f)) * 15.0f;
-    //        lightPosRadius[ii][1] =
-    //            glm::cos((m_timePassed * (0.2f + ii * 0.29f) + ii * glm::half_pi<float>() * 1.49f)) * 15.0f;
-    //        lightPosRadius[ii][2] = 15.5f;
-    //        lightPosRadius[ii][3] = 17.0f;
-    //    }
-    //
-    //    bgfx::setUniform(u_lightPosRadius, lightPosRadius, m_numLights);
-    //
-    //    float lightRgbInnerR[4][4] = {
-    //        {1.0f, 0.7f, 0.2f, 0.8f},
-    //        {0.7f, 0.2f, 1.0f, 0.8f},
-    //        {0.2f, 1.0f, 0.7f, 0.8f},
-    //        {1.0f, 0.4f, 0.2f, 0.8f},
-    //    };
-    //
-    //    bgfx::setUniform(u_lightRgbInnerR, lightRgbInnerR, m_numLights);
-    //
-    //    for (uint32_t yy = 0; yy < 11; ++yy) {
-    //        for (uint32_t xx = 0; xx < 11; ++xx) {
-    //            glm::mat4 mtx = glm::identity<glm::mat4>();
-    //            mtx = glm::translate(mtx, glm::vec3(15.0f - float(xx) * 3.0f, -15.0f + float(yy) * 3.0f, 30.0f));
-    //            mtx *= glm::yawPitchRoll(m_timePassed + xx * 0.21f, m_timePassed + yy * 0.37f, 0.0f);
-    //            bgfx::setTransform(&mtx[0][0]);
-    //
-    //            // Set vertex and index buffer.
-    //            bgfx::setVertexBuffer(0, m_cube.get_vertex_buffer());
-    //            bgfx::setIndexBuffer(m_cube.get_index_buffer());
-    //
-    //            // Bind textures.
-    //            bgfx::setTexture(0, s_texColor, m_textureColor);
-    //            bgfx::setTexture(1, s_texNormal, m_textureNormal);
-    //
-    //            bgfx::setState(0 | BGFX_STATE_WRITE_RGB | BGFX_STATE_WRITE_A | BGFX_STATE_WRITE_Z |
-    //                           BGFX_STATE_DEPTH_TEST_LESS | BGFX_STATE_MSAA);
-    //
-    //            bgfx::submit(0, m_shaderProgram.get_program());
-    //        }
-    //    }
-    //
-    //    bgfx::frame();
-}
+void ForwardRenderer::on_render() {}
 
 void ForwardRenderer::on_post_render() {}
 

--- a/core/src/forward_renderer.cpp
+++ b/core/src/forward_renderer.cpp
@@ -85,19 +85,7 @@ void ForwardRenderer::render_pbr() {
 
     //=PBR PIPELINE===========================
 
-    //        auto entities = registry.view<Transform, InstanceMesh, Material, Name>();
-    //        for (auto& e : entities) {
-    //            auto goOpt = scene.get_game_object_from_handle(e);
-    //            if (!goOpt) {
-    //                continue;
-    //            }
-    //
-    //            GameObject go = goOpt.value();
-    //            Transform& transform = go.get_component<Transform>();
-    //            InstanceMesh& mesh = go.get_component<InstanceMesh>();
-    //            Material& material = go.get_component<Material>();
-    //            Name& name = go.get_component<Name>();
-    auto entities = registry.view<Transform, Mesh, Material, Name>();
+    auto entities = registry.view<Transform, InstanceMesh, Material, Name>();
     for (auto& e : entities) {
         auto goOpt = scene.get_game_object_from_handle(e);
         if (!goOpt) {
@@ -106,7 +94,7 @@ void ForwardRenderer::render_pbr() {
 
         GameObject go = goOpt.value();
         Transform& transform = go.get_component<Transform>();
-        Mesh& mesh = go.get_component<Mesh>();
+        InstanceMesh& mesh = go.get_component<InstanceMesh>();
         Material& material = go.get_component<Material>();
         Name& name = go.get_component<Name>();
 
@@ -118,21 +106,18 @@ void ForwardRenderer::render_pbr() {
         bgfx::setTransform(value_ptr(transform.get_model_matrix()));
 
         // Set vertex and index buffer.
+        bgfx::setVertexBuffer(0, mesh.get_vertex_buffer());
 
-
-        bgfx::setVertexBuffer(0, *mesh.get_vertex_buffer());
-
-        //        log::info("CHECK VALID {} {}", isValid(*mesh.get_vertex_buffer()),isValid(*mesh.get_index_buffer()));
-
-        if (isValid(*mesh.get_index_buffer())) {
-            bgfx::setIndexBuffer(*mesh.get_index_buffer());
+        if (isValid(mesh.get_index_buffer())) {
+            bgfx::setIndexBuffer(mesh.get_index_buffer());
         }
 
         // Bind Uniforms & textures.
         material.set_uniforms();
 
         // TODO enable MSAA in bgfx
-        bgfx::setState(0 | BGFX_STATE_MSAA | BGFX_STATE_WRITE_RGB | BGFX_STATE_WRITE_A | BGFX_STATE_WRITE_Z | BGFX_STATE_DEPTH_TEST_LESS);
+        bgfx::setState(0 | BGFX_STATE_MSAA | BGFX_STATE_WRITE_RGB | BGFX_STATE_WRITE_A | BGFX_STATE_WRITE_Z |
+                       BGFX_STATE_DEPTH_TEST_LESS);
 
         bgfx::submit(0, material.get_program());
     }

--- a/core/src/forward_renderer.cpp
+++ b/core/src/forward_renderer.cpp
@@ -1,5 +1,6 @@
 #include <bgfx/bgfx.h>
 #include <knoting/forward_renderer.h>
+#include <knoting/instance_mesh.h>
 #include <knoting/mesh.h>
 #include <knoting/texture.h>
 
@@ -84,6 +85,18 @@ void ForwardRenderer::render_pbr() {
 
     //=PBR PIPELINE===========================
 
+    //        auto entities = registry.view<Transform, InstanceMesh, Material, Name>();
+    //        for (auto& e : entities) {
+    //            auto goOpt = scene.get_game_object_from_handle(e);
+    //            if (!goOpt) {
+    //                continue;
+    //            }
+    //
+    //            GameObject go = goOpt.value();
+    //            Transform& transform = go.get_component<Transform>();
+    //            InstanceMesh& mesh = go.get_component<InstanceMesh>();
+    //            Material& material = go.get_component<Material>();
+    //            Name& name = go.get_component<Name>();
     auto entities = registry.view<Transform, Mesh, Material, Name>();
     for (auto& e : entities) {
         auto goOpt = scene.get_game_object_from_handle(e);
@@ -105,17 +118,21 @@ void ForwardRenderer::render_pbr() {
         bgfx::setTransform(value_ptr(transform.get_model_matrix()));
 
         // Set vertex and index buffer.
-        bgfx::setVertexBuffer(0, mesh.get_vertex_buffer());
 
-        if (isValid(mesh.get_index_buffer())) {
-            bgfx::setIndexBuffer(mesh.get_index_buffer());
+
+        bgfx::setVertexBuffer(0, *mesh.get_vertex_buffer());
+
+        //        log::info("CHECK VALID {} {}", isValid(*mesh.get_vertex_buffer()),isValid(*mesh.get_index_buffer()));
+
+        if (isValid(*mesh.get_index_buffer())) {
+            bgfx::setIndexBuffer(*mesh.get_index_buffer());
         }
 
         // Bind Uniforms & textures.
         material.set_uniforms();
 
         // TODO enable MSAA in bgfx
-        bgfx::setState(0 | BGFX_STATE_WRITE_RGB | BGFX_STATE_WRITE_A | BGFX_STATE_WRITE_Z | BGFX_STATE_DEPTH_TEST_LESS);
+        bgfx::setState(0 | BGFX_STATE_MSAA | BGFX_STATE_WRITE_RGB | BGFX_STATE_WRITE_A | BGFX_STATE_WRITE_Z | BGFX_STATE_DEPTH_TEST_LESS);
 
         bgfx::submit(0, material.get_program());
     }

--- a/core/src/image_loader.cpp
+++ b/core/src/image_loader.cpp
@@ -1,0 +1,4 @@
+#include <knoting/asset_loaders/image_loader.h>
+namespace knot{
+
+}

--- a/core/src/image_loader.cpp
+++ b/core/src/image_loader.cpp
@@ -1,4 +1,2 @@
 #include <knoting/asset_loaders/image_loader.h>
-namespace knot{
-
-}
+namespace knot {}

--- a/core/src/instance_mesh.cpp
+++ b/core/src/instance_mesh.cpp
@@ -1,0 +1,14 @@
+#include <knoting/instance_mesh.h>
+
+namespace knot {
+InstanceMesh::InstanceMesh() {}
+InstanceMesh::InstanceMesh(const std::string& path) : m_path(path) {}
+
+void InstanceMesh::on_awake() {
+    log::info("LOOKING FOR MESH FOR INSTANCED LAD");
+    m_instance_mesh = AssetManager::load_asset<components::Mesh>(m_path).lock();
+}
+
+void InstanceMesh::on_destroy() {}
+
+}  // namespace knot

--- a/core/src/instance_mesh.cpp
+++ b/core/src/instance_mesh.cpp
@@ -5,8 +5,7 @@ InstanceMesh::InstanceMesh() {}
 InstanceMesh::InstanceMesh(const std::string& path) : m_path(path) {}
 
 void InstanceMesh::on_awake() {
-    log::info("LOOKING FOR MESH FOR INSTANCED LAD");
-    m_instance_mesh = AssetManager::load_asset<components::Mesh>(m_path).lock();
+    m_mesh = AssetManager::load_asset<components::Mesh>(m_path).lock();
 }
 
 void InstanceMesh::on_destroy() {}

--- a/core/src/light_data.cpp
+++ b/core/src/light_data.cpp
@@ -28,14 +28,14 @@ void LightData::set_spotlight_count(uint16_t count) {
     m_spotlightData.m_amountOfSpotlights = count;
 }
 
-LightData::SpotlightData::SpotlightData() {
+SpotlightData::SpotlightData() {
     // TODO replace "u_spotlightRgbInnerR" with "u_spotlightPosRadius" when pbr shader is impl
     // TODO replace "u_lightRgbInnerR" with "u_spotlightRgbInnerR" when pbr shader is impl
     u_spotlightPosRadius = bgfx::createUniform("u_lightPosRadius", bgfx::UniformType::Vec4);
     u_spotlightRgbInnerR = bgfx::createUniform("u_lightRgbInnerR", bgfx::UniformType::Vec4);
 }
 
-LightData::SpotlightData::~SpotlightData() {
+SpotlightData::~SpotlightData() {
     bgfx::destroy(u_spotlightPosRadius);
     bgfx::destroy(u_spotlightRgbInnerR);
 }

--- a/core/src/light_data.cpp
+++ b/core/src/light_data.cpp
@@ -1,0 +1,43 @@
+#include <knoting/light_data.h>
+
+namespace knot {
+
+LightData::LightData() {}
+
+void LightData::set_spotlight_uniforms() {
+    bgfx::setUniform(m_spotlightData.u_spotlightPosRadius, m_spotlightData.m_spotlightsPositionOuterRadius.data(),
+                     m_spotlightData.m_amountOfSpotlights);
+    bgfx::setUniform(m_spotlightData.u_spotlightRgbInnerR, m_spotlightData.m_spotlightsColorInnerRadius.data(),
+                     m_spotlightData.m_amountOfSpotlights);
+}
+
+void LightData::clear_spotlight() {
+    m_spotlightData.m_spotlightsPositionOuterRadius.clear();
+    m_spotlightData.m_spotlightsColorInnerRadius.clear();
+}
+
+void LightData::push_spotlight_pos_outer_rad(vec4 posOutRad) {
+    m_spotlightData.m_spotlightsPositionOuterRadius.emplace_back(posOutRad);
+}
+
+void LightData::push_spotlight_color_inner_rad(vec4 colInRad) {
+    m_spotlightData.m_spotlightsColorInnerRadius.emplace_back(colInRad);
+}
+
+void LightData::set_spotlight_count(uint16_t count) {
+    m_spotlightData.m_amountOfSpotlights = count;
+}
+
+LightData::SpotlightData::SpotlightData() {
+    // TODO replace "u_spotlightRgbInnerR" with "u_spotlightPosRadius" when pbr shader is impl
+    // TODO replace "u_lightRgbInnerR" with "u_spotlightRgbInnerR" when pbr shader is impl
+    u_spotlightPosRadius = bgfx::createUniform("u_lightPosRadius", bgfx::UniformType::Vec4);
+    u_spotlightRgbInnerR = bgfx::createUniform("u_lightRgbInnerR", bgfx::UniformType::Vec4);
+}
+
+LightData::SpotlightData::~SpotlightData() {
+    bgfx::destroy(u_spotlightPosRadius);
+    bgfx::destroy(u_spotlightRgbInnerR);
+}
+
+}  // namespace knot

--- a/core/src/light_data.cpp
+++ b/core/src/light_data.cpp
@@ -16,12 +16,12 @@ void LightData::clear_spotlight() {
     m_spotlightData.m_spotlightsColorInnerRadius.clear();
 }
 
-void LightData::push_spotlight_pos_outer_rad(vec4 posOutRad) {
-    m_spotlightData.m_spotlightsPositionOuterRadius.emplace_back(posOutRad);
+void LightData::push_spotlight_pos_outer_rad(vec4 positionAndOuterRadius) {
+    m_spotlightData.m_spotlightsPositionOuterRadius.emplace_back(positionAndOuterRadius);
 }
 
-void LightData::push_spotlight_color_inner_rad(vec4 colInRad) {
-    m_spotlightData.m_spotlightsColorInnerRadius.emplace_back(colInRad);
+void LightData::push_spotlight_color_inner_rad(vec4 colorAndInnerRadius) {
+    m_spotlightData.m_spotlightsColorInnerRadius.emplace_back(colorAndInnerRadius);
 }
 
 void LightData::set_spotlight_count(uint16_t count) {

--- a/core/src/material.cpp
+++ b/core/src/material.cpp
@@ -29,18 +29,11 @@ void Material::on_awake() {
     m_uniformSamplerHandle[(size_t)UniformSamplerHandle::Roughness] = bgfx::createUniform("m_roughness", bgfx::UniformType::Sampler);
     m_uniformSamplerHandle[(size_t)UniformSamplerHandle::Occlusion] = bgfx::createUniform("m_occlusion", bgfx::UniformType::Sampler);
 
-    m_albedo = AssetManager::load_asset<components::Texture>(m_textureSlotPath[(int)TextureHandle::Albedo]).lock();
-    m_normal = AssetManager::load_asset<components::Texture>(m_textureSlotPath[(int)TextureHandle::Normal]).lock();
-    m_metallic = AssetManager::load_asset<components::Texture>(m_textureSlotPath[(int)TextureHandle::Metallic]).lock();
+    m_albedo    = AssetManager::load_asset<components::Texture>(m_textureSlotPath[(int)TextureHandle::Albedo]).lock();
+    m_normal    = AssetManager::load_asset<components::Texture>(m_textureSlotPath[(int)TextureHandle::Normal]).lock();
+    m_metallic  = AssetManager::load_asset<components::Texture>(m_textureSlotPath[(int)TextureHandle::Metallic]).lock();
     m_roughness = AssetManager::load_asset<components::Texture>(m_textureSlotPath[(int)TextureHandle::Roughness]).lock();
     m_occlusion = AssetManager::load_asset<components::Texture>(m_textureSlotPath[(int)TextureHandle::Occlusion]).lock();
-    log::debug("LOADED TEXTURE PATH");
-    log::debug(m_textureSlotPath[(int)TextureHandle::Albedo]);
-    log::debug(m_textureSlotPath[(int)TextureHandle::Normal]);
-    log::debug(m_textureSlotPath[(int)TextureHandle::Metallic]);
-    log::debug(m_textureSlotPath[(int)TextureHandle::Roughness]);
-    log::debug(m_textureSlotPath[(int)TextureHandle::Occlusion]);
-
 
     m_textureHandles[(size_t)TextureHandle::Albedo]    = m_albedo->get_texture_handle();
     m_textureHandles[(size_t)TextureHandle::Normal]    = m_normal->get_texture_handle();
@@ -133,9 +126,7 @@ switch (slot) {
         default:
             return;
     }
-    //TODO THIS IS BROKEN IT IS NOT SETTING THE PATH CORRECTLY
     m_textureSlotPath[(int)slot] = path;
-    log::debug(std::to_string((int)slot) + path);
 }
 
 }  // namespace components

--- a/core/src/material.cpp
+++ b/core/src/material.cpp
@@ -29,11 +29,18 @@ void Material::on_awake() {
     m_uniformSamplerHandle[(size_t)UniformSamplerHandle::Roughness] = bgfx::createUniform("m_roughness", bgfx::UniformType::Sampler);
     m_uniformSamplerHandle[(size_t)UniformSamplerHandle::Occlusion] = bgfx::createUniform("m_occlusion", bgfx::UniformType::Sampler);
 
-    m_albedo = AssetManager::load_asset<components::Texture>("UV_Grid_test.png").lock();
-    m_normal = AssetManager::load_asset<components::Texture>("normal_tiles_1k.png").lock();
-    m_metallic = AssetManager::load_asset<components::Texture>("UV_Grid_test.png").lock();
-    m_roughness = AssetManager::load_asset<components::Texture>("UV_Grid_test.png").lock();
-    m_occlusion = AssetManager::load_asset<components::Texture>("UV_Grid_test.png").lock();
+    m_albedo = AssetManager::load_asset<components::Texture>(m_textureSlotPath[(int)TextureHandle::Albedo]).lock();
+    m_normal = AssetManager::load_asset<components::Texture>(m_textureSlotPath[(int)TextureHandle::Normal]).lock();
+    m_metallic = AssetManager::load_asset<components::Texture>(m_textureSlotPath[(int)TextureHandle::Metallic]).lock();
+    m_roughness = AssetManager::load_asset<components::Texture>(m_textureSlotPath[(int)TextureHandle::Roughness]).lock();
+    m_occlusion = AssetManager::load_asset<components::Texture>(m_textureSlotPath[(int)TextureHandle::Occlusion]).lock();
+    log::debug("LOADED TEXTURE PATH");
+    log::debug(m_textureSlotPath[(int)TextureHandle::Albedo]);
+    log::debug(m_textureSlotPath[(int)TextureHandle::Normal]);
+    log::debug(m_textureSlotPath[(int)TextureHandle::Metallic]);
+    log::debug(m_textureSlotPath[(int)TextureHandle::Roughness]);
+    log::debug(m_textureSlotPath[(int)TextureHandle::Occlusion]);
+
 
     m_textureHandles[(size_t)TextureHandle::Albedo]    = m_albedo->get_texture_handle();
     m_textureHandles[(size_t)TextureHandle::Normal]    = m_normal->get_texture_handle();
@@ -110,6 +117,25 @@ void Material::set_uniforms() {
     bgfx::setTexture(4, m_uniformSamplerHandle[(size_t)UniformSamplerHandle::Occlusion],m_textureHandles[(size_t)TextureHandle::Occlusion]);
 
     // clang-format off
+}
+void Material::set_texture_slot_path(TextureType slot, const std::string& path){
+switch (slot) {
+        case TextureType::Albedo:
+            break;
+        case TextureType::Normal:
+            break;
+        case TextureType::Metallic:
+            break;
+        case TextureType::Roughness:
+            break;
+        case TextureType::Occlusion:
+            break;
+        default:
+            return;
+    }
+    //TODO THIS IS BROKEN IT IS NOT SETTING THE PATH CORRECTLY
+    m_textureSlotPath[(int)slot] = path;
+    log::debug(std::to_string((int)slot) + path);
 }
 
 }  // namespace components

--- a/core/src/material.cpp
+++ b/core/src/material.cpp
@@ -31,19 +31,21 @@ void Material::on_awake() {
 
     // TODO Get Textures from resource manager
 
-    m_albedo.load_texture_2d("UV_Grid_test.png");
-    m_normal.load_texture_2d("normal_tiles_1k.png");
-    m_metallic.load_texture_2d("UV_Grid_test.png");
-    m_roughness.load_texture_2d("UV_Grid_test.png");
-    m_occlusion.load_texture_2d("UV_Grid_test.png");
+    m_albedo = AssetManager::load_asset<components::Texture>("UV_Grid_test.png").lock();
+    m_normal = AssetManager::load_asset<components::Texture>("normal_tiles_1k.png").lock();
+    m_metallic = AssetManager::load_asset<components::Texture>("UV_Grid_test.png").lock();
+    m_roughness = AssetManager::load_asset<components::Texture>("UV_Grid_test.png").lock();
+    m_occlusion = AssetManager::load_asset<components::Texture>("UV_Grid_test.png").lock();
 
     // end TODO
+    {
+    }
 
-    m_textureHandles[(size_t)TextureHandle::Albedo]    = m_albedo.get_texture_handle();
-    m_textureHandles[(size_t)TextureHandle::Normal]    = m_normal.get_texture_handle();
-    m_textureHandles[(size_t)TextureHandle::Metallic]  = m_metallic.get_texture_handle();
-    m_textureHandles[(size_t)TextureHandle::Roughness] = m_roughness.get_texture_handle();
-    m_textureHandles[(size_t)TextureHandle::Occlusion] = m_occlusion.get_texture_handle();
+    m_textureHandles[(size_t)TextureHandle::Albedo]    = m_albedo->get_texture_handle();
+    m_textureHandles[(size_t)TextureHandle::Normal]    = m_normal->get_texture_handle();
+    m_textureHandles[(size_t)TextureHandle::Metallic]  = m_metallic->get_texture_handle();
+    m_textureHandles[(size_t)TextureHandle::Roughness] = m_roughness->get_texture_handle();
+    m_textureHandles[(size_t)TextureHandle::Occlusion] = m_occlusion->get_texture_handle();
 
     // clang-format on
 }
@@ -107,7 +109,15 @@ void Material::set_uniforms() {
     bgfx::setUniform(m_uniformHandles[(size_t)UniformHandle::AlphaCutoffEnabled], &m_alphaCutoffEnabled);
     bgfx::setUniform(m_uniformHandles[(size_t)UniformHandle::AlphaCutoffAmount],  &m_alphaCutoffAmount);
 
+    int i = 0;
+    for(auto t : m_textureHandles){
+        log::debug("id {}, is valid {}, idx {}",i,isValid(t), t.idx);
+        i++;
+    }
+
+log::debug("BEFORE");
     bgfx::setTexture(0, m_uniformSamplerHandle[(size_t)UniformSamplerHandle::Albedo],   m_textureHandles[(size_t)TextureHandle::Albedo]);
+log::debug("BEFORE");
     bgfx::setTexture(1, m_uniformSamplerHandle[(size_t)UniformSamplerHandle::Normal],   m_textureHandles[(size_t)TextureHandle::Normal]);
     bgfx::setTexture(2, m_uniformSamplerHandle[(size_t)UniformSamplerHandle::Metallic], m_textureHandles[(size_t)TextureHandle::Metallic]);
     bgfx::setTexture(3, m_uniformSamplerHandle[(size_t)UniformSamplerHandle::Roughness],m_textureHandles[(size_t)TextureHandle::Roughness]);

--- a/core/src/material.cpp
+++ b/core/src/material.cpp
@@ -29,17 +29,11 @@ void Material::on_awake() {
     m_uniformSamplerHandle[(size_t)UniformSamplerHandle::Roughness] = bgfx::createUniform("m_roughness", bgfx::UniformType::Sampler);
     m_uniformSamplerHandle[(size_t)UniformSamplerHandle::Occlusion] = bgfx::createUniform("m_occlusion", bgfx::UniformType::Sampler);
 
-    // TODO Get Textures from resource manager
-
     m_albedo = AssetManager::load_asset<components::Texture>("UV_Grid_test.png").lock();
     m_normal = AssetManager::load_asset<components::Texture>("normal_tiles_1k.png").lock();
     m_metallic = AssetManager::load_asset<components::Texture>("UV_Grid_test.png").lock();
     m_roughness = AssetManager::load_asset<components::Texture>("UV_Grid_test.png").lock();
     m_occlusion = AssetManager::load_asset<components::Texture>("UV_Grid_test.png").lock();
-
-    // end TODO
-    {
-    }
 
     m_textureHandles[(size_t)TextureHandle::Albedo]    = m_albedo->get_texture_handle();
     m_textureHandles[(size_t)TextureHandle::Normal]    = m_normal->get_texture_handle();
@@ -109,15 +103,7 @@ void Material::set_uniforms() {
     bgfx::setUniform(m_uniformHandles[(size_t)UniformHandle::AlphaCutoffEnabled], &m_alphaCutoffEnabled);
     bgfx::setUniform(m_uniformHandles[(size_t)UniformHandle::AlphaCutoffAmount],  &m_alphaCutoffAmount);
 
-    int i = 0;
-    for(auto t : m_textureHandles){
-        log::debug("id {}, is valid {}, idx {}",i,isValid(t), t.idx);
-        i++;
-    }
-
-log::debug("BEFORE");
     bgfx::setTexture(0, m_uniformSamplerHandle[(size_t)UniformSamplerHandle::Albedo],   m_textureHandles[(size_t)TextureHandle::Albedo]);
-log::debug("BEFORE");
     bgfx::setTexture(1, m_uniformSamplerHandle[(size_t)UniformSamplerHandle::Normal],   m_textureHandles[(size_t)TextureHandle::Normal]);
     bgfx::setTexture(2, m_uniformSamplerHandle[(size_t)UniformSamplerHandle::Metallic], m_textureHandles[(size_t)TextureHandle::Metallic]);
     bgfx::setTexture(3, m_uniformSamplerHandle[(size_t)UniformSamplerHandle::Roughness],m_textureHandles[(size_t)TextureHandle::Roughness]);

--- a/core/src/mesh.cpp
+++ b/core/src/mesh.cpp
@@ -8,8 +8,8 @@ using namespace std::chrono;
 namespace knot {
 namespace components {
 
-Mesh::Mesh() : Asset{AssetType::Mesh, "", "fallbackMesh"} {}
-Mesh::Mesh(const std::string& path) : Asset{AssetType::Mesh, path, "fallbackMesh"} {}
+Mesh::Mesh() : Asset{AssetType::Mesh, ""} {}
+Mesh::Mesh(const std::string& path) : Asset{AssetType::Mesh, path} {}
 
 Mesh::~Mesh() {}
 

--- a/core/src/mesh.cpp
+++ b/core/src/mesh.cpp
@@ -15,7 +15,6 @@ void Mesh::on_awake() {
     if (m_assetState != AssetState::Finished) {
         m_assetState = AssetState::Loading;
         internal_load_obj(m_fullPath);
-        // generate_default_asset();
     }
 }
 
@@ -27,20 +26,6 @@ void Mesh::on_destroy() {
         bgfx::destroy(m_ibh);
     }
     log::info("removed mesh : {}", m_fullPath);
-}
-
-void Mesh::load_mesh(const std::string& localTexturePath) {
-    std::string fullPath = PATH_MODELS + localTexturePath;
-    std::filesystem::path fs_path = std::filesystem::path(fullPath);
-    bgfx::TextureHandle handle = BGFX_INVALID_HANDLE;
-
-    if (std::filesystem::exists(fs_path)) {
-        log::debug("file loaded at : " + fullPath);
-        internal_load_obj(fullPath);
-
-    } else {
-        log::error("file : " + fullPath + " does not exist");
-    }
 }
 
 void Mesh::create_cube() {
@@ -193,20 +178,20 @@ bool Mesh::internal_load_obj(const std::string& path) {
                     std::vector<std::string> data = split(faceData, "/");
                     // vertex index
                     if (data[0].size() > 0) {
-                        sscanf_s(data[0].c_str(), "%d", &vertexIndex);
+                        sscanf(data[0].c_str(), "%d", &vertexIndex);
                         vertexIndices.push_back(vertexIndex);
                     }
                     // if the face vertex has a texture coord index
                     if (data.size() >= 1) {
                         if (data[1].size() > 0) {
-                            sscanf_s(data[1].c_str(), "%d", &uvIndex);
+                            sscanf(data[1].c_str(), "%d", &uvIndex);
                             uvIndices.push_back(uvIndex);
                         }
                     }
                     // does the face vertex have a normal index
                     if (data.size() >= 2) {
                         if (data[2].size() > 0) {
-                            sscanf_s(data[2].c_str(), "%d", &normalIndex);
+                            sscanf(data[2].c_str(), "%d", &normalIndex);
                             normalIndices.push_back(normalIndex);
                         }
                     }

--- a/core/src/mesh.cpp
+++ b/core/src/mesh.cpp
@@ -99,10 +99,9 @@ void Mesh::generate_default_asset() {
     log::info("Fallback created");
 }
 
-std::vector<std::string> m_splitResult;
-std::vector<std::string> split(std::string s, std::string t) {
+std::vector<std::string> Mesh::split(std::string s, std::string t) {
     m_splitResult.clear();
-    while (1) {
+    while (!s.empty()) {
         int pos = s.find(t);
         if (pos == -1) {
             m_splitResult.push_back(s);

--- a/core/src/mesh.cpp
+++ b/core/src/mesh.cpp
@@ -5,7 +5,8 @@
 namespace knot {
 namespace components {
 
-Mesh::Mesh() {}
+Mesh::Mesh() : Asset{AssetType::MESH, ""} {}
+Mesh::Mesh(const std::string& path) : Asset{AssetType::MESH, path} {}
 
 Mesh::~Mesh() {}
 
@@ -17,6 +18,7 @@ void Mesh::on_destroy() {
 }
 
 void Mesh::load_mesh(const std::string& localTexturePath) {
+
     std::string fullPath = PATH_MODELS + localTexturePath;
     std::filesystem::path fs_path = std::filesystem::path(fullPath);
     bgfx::TextureHandle handle = BGFX_INVALID_HANDLE;

--- a/core/src/mesh.cpp
+++ b/core/src/mesh.cpp
@@ -52,29 +52,29 @@ void Mesh::create_cube() {
     VertexLayout::init();
     m_vertexLayout = {
         {-1.0f, 1.0f, 1.0f, encode_normal_rgba8(0.0f, 0.0f, 1.0f), 0, 0, 0},
-        {1.0f, 1.0f, 1.0f, encode_normal_rgba8(0.0f, 0.0f, 1.0f), 0, 0x7fff, 0},
-        {-1.0f, -1.0f, 1.0f, encode_normal_rgba8(0.0f, 0.0f, 1.0f), 0, 0, 0x7fff},
-        {1.0f, -1.0f, 1.0f, encode_normal_rgba8(0.0f, 0.0f, 1.0f), 0, 0x7fff, 0x7fff},
+        {1.0f, 1.0f, 1.0f, encode_normal_rgba8(0.0f, 0.0f, 1.0f), 0, 1, 0},
+        {-1.0f, -1.0f, 1.0f, encode_normal_rgba8(0.0f, 0.0f, 1.0f), 0, 0, 1},
+        {1.0f, -1.0f, 1.0f, encode_normal_rgba8(0.0f, 0.0f, 1.0f), 0, 1, 1},
         {-1.0f, 1.0f, -1.0f, encode_normal_rgba8(0.0f, 0.0f, -1.0f), 0, 0, 0},
-        {1.0f, 1.0f, -1.0f, encode_normal_rgba8(0.0f, 0.0f, -1.0f), 0, 0x7fff, 0},
-        {-1.0f, -1.0f, -1.0f, encode_normal_rgba8(0.0f, 0.0f, -1.0f), 0, 0, 0x7fff},
-        {1.0f, -1.0f, -1.0f, encode_normal_rgba8(0.0f, 0.0f, -1.0f), 0, 0x7fff, 0x7fff},
+        {1.0f, 1.0f, -1.0f, encode_normal_rgba8(0.0f, 0.0f, -1.0f), 0, 1, 0},
+        {-1.0f, -1.0f, -1.0f, encode_normal_rgba8(0.0f, 0.0f, -1.0f), 0, 0, 1},
+        {1.0f, -1.0f, -1.0f, encode_normal_rgba8(0.0f, 0.0f, -1.0f), 0, 1, 1},
         {-1.0f, 1.0f, 1.0f, encode_normal_rgba8(0.0f, 1.0f, 0.0f), 0, 0, 0},
-        {1.0f, 1.0f, 1.0f, encode_normal_rgba8(0.0f, 1.0f, 0.0f), 0, 0x7fff, 0},
-        {-1.0f, 1.0f, -1.0f, encode_normal_rgba8(0.0f, 1.0f, 0.0f), 0, 0, 0x7fff},
-        {1.0f, 1.0f, -1.0f, encode_normal_rgba8(0.0f, 1.0f, 0.0f), 0, 0x7fff, 0x7fff},
+        {1.0f, 1.0f, 1.0f, encode_normal_rgba8(0.0f, 1.0f, 0.0f), 0, 1, 0},
+        {-1.0f, 1.0f, -1.0f, encode_normal_rgba8(0.0f, 1.0f, 0.0f), 0, 0, 1},
+        {1.0f, 1.0f, -1.0f, encode_normal_rgba8(0.0f, 1.0f, 0.0f), 0, 1, 1},
         {-1.0f, -1.0f, 1.0f, encode_normal_rgba8(0.0f, -1.0f, 0.0f), 0, 0, 0},
-        {1.0f, -1.0f, 1.0f, encode_normal_rgba8(0.0f, -1.0f, 0.0f), 0, 0x7fff, 0},
-        {-1.0f, -1.0f, -1.0f, encode_normal_rgba8(0.0f, -1.0f, 0.0f), 0, 0, 0x7fff},
-        {1.0f, -1.0f, -1.0f, encode_normal_rgba8(0.0f, -1.0f, 0.0f), 0, 0x7fff, 0x7fff},
+        {1.0f, -1.0f, 1.0f, encode_normal_rgba8(0.0f, -1.0f, 0.0f), 0, 1, 0},
+        {-1.0f, -1.0f, -1.0f, encode_normal_rgba8(0.0f, -1.0f, 0.0f), 0, 0, 1},
+        {1.0f, -1.0f, -1.0f, encode_normal_rgba8(0.0f, -1.0f, 0.0f), 0, 1, 1},
         {1.0f, -1.0f, 1.0f, encode_normal_rgba8(1.0f, 0.0f, 0.0f), 0, 0, 0},
-        {1.0f, 1.0f, 1.0f, encode_normal_rgba8(1.0f, 0.0f, 0.0f), 0, 0x7fff, 0},
-        {1.0f, -1.0f, -1.0f, encode_normal_rgba8(1.0f, 0.0f, 0.0f), 0, 0, 0x7fff},
-        {1.0f, 1.0f, -1.0f, encode_normal_rgba8(1.0f, 0.0f, 0.0f), 0, 0x7fff, 0x7fff},
+        {1.0f, 1.0f, 1.0f, encode_normal_rgba8(1.0f, 0.0f, 0.0f), 0, 1, 0},
+        {1.0f, -1.0f, -1.0f, encode_normal_rgba8(1.0f, 0.0f, 0.0f), 0, 0, 1},
+        {1.0f, 1.0f, -1.0f, encode_normal_rgba8(1.0f, 0.0f, 0.0f), 0, 1, 1},
         {-1.0f, -1.0f, 1.0f, encode_normal_rgba8(-1.0f, 0.0f, 0.0f), 0, 0, 0},
-        {-1.0f, 1.0f, 1.0f, encode_normal_rgba8(-1.0f, 0.0f, 0.0f), 0, 0x7fff, 0},
-        {-1.0f, -1.0f, -1.0f, encode_normal_rgba8(-1.0f, 0.0f, 0.0f), 0, 0, 0x7fff},
-        {-1.0f, 1.0f, -1.0f, encode_normal_rgba8(-1.0f, 0.0f, 0.0f), 0, 0x7fff, 0x7fff},
+        {-1.0f, 1.0f, 1.0f, encode_normal_rgba8(-1.0f, 0.0f, 0.0f), 0, 1, 0},
+        {-1.0f, -1.0f, -1.0f, encode_normal_rgba8(-1.0f, 0.0f, 0.0f), 0, 0, 1},
+        {-1.0f, 1.0f, -1.0f, encode_normal_rgba8(-1.0f, 0.0f, 0.0f), 0, 1, 1},
     };
 
     m_vbh =
@@ -204,33 +204,21 @@ bool Mesh::internal_load_obj(const std::string& fileName) {
     std::vector<int16_t> tempIndex;
     int ind = 0;
     for (auto v : mVertices) {
-        log::info("U : {} , V : {}", (int16_t)v.texCoords.x,(int16_t)v.texCoords.y);
+        log::info("U : {} , V : {}", (int16_t)v.texCoords.x, (int16_t)v.texCoords.y);
         tempIndex.emplace_back(ind);
-        m_vertexLayout.emplace_back(
-            VertexLayout{
-                v.position.x,
-                v.position.y,
-                v.position.z,
-                encode_normal_rgba8(v.normal.x, v.normal.y, v.normal.z),
-                0,
-                (int16_t)v.texCoords.x,
-                (int16_t)v.texCoords.y
-            }
-        );
+        m_vertexLayout.emplace_back(VertexLayout{v.position.x, v.position.y, v.position.z,
+                                                 encode_normal_rgba8(v.normal.x, v.normal.y, v.normal.z), 0,
+                                                 v.texCoords.x, v.texCoords.y});
         ind++;
     }
-//    for (auto buffer : mVertices) {
-//        log::info("POS : x: {} , y: {} , z: {}", buffer.position.x, buffer.position.y, buffer.position.z);
-//        log::info("NRM : {},{},{}", buffer.normal.x, buffer.normal.y, buffer.normal.z);
-//        log::info("UV : u : {} , v : {}", buffer.texCoords.x, buffer.texCoords.y);
-//    }
 
     m_indexBuffer = std::make_shared<IndexBuffer>();
     m_indexBuffer->set_index_buffer(tempIndex);
 
     m_ibh = bgfx::createIndexBuffer(bgfx::makeRef(&m_indexBuffer->get_index_start(), m_indexBuffer->get_memory_size()));
 
-    m_vbh = bgfx::createVertexBuffer(bgfx::makeRef(&m_vertexLayout[0], sizeof(m_vertexLayout[0]) * m_vertexLayout.size()),
+    m_vbh =
+        bgfx::createVertexBuffer(bgfx::makeRef(&m_vertexLayout[0], sizeof(m_vertexLayout[0]) * m_vertexLayout.size()),
                                  VertexLayout::s_meshVertexLayout);
     log::debug("init buffers {}", fileName);
 

--- a/core/src/mesh.cpp
+++ b/core/src/mesh.cpp
@@ -99,11 +99,11 @@ void Mesh::generate_default_asset() {
     log::info("Fallback created");
 }
 
-std::vector<std::string> Mesh::split(std::string s, std::string t) {
+std::vector<std::string> Mesh::split(std::string s, const std::string& t) {
     m_splitResult.clear();
     while (!s.empty()) {
-        int pos = s.find(t);
-        if (pos == -1) {
+        size_t pos = s.find(t);
+        if (pos == std::string::npos) {
             m_splitResult.push_back(s);
             break;
         }

--- a/core/src/mesh.cpp
+++ b/core/src/mesh.cpp
@@ -5,8 +5,8 @@
 namespace knot {
 namespace components {
 
-Mesh::Mesh() : Asset{AssetType::MESH, ""} {}
-Mesh::Mesh(const std::string& path) : Asset{AssetType::MESH, path} {}
+Mesh::Mesh() : Asset{AssetType::MESH, "", "fallbackMesh"} {}
+Mesh::Mesh(const std::string& path) : Asset{AssetType::MESH, path, "fallbackMesh"} {}
 
 Mesh::~Mesh() {}
 
@@ -76,6 +76,8 @@ void Mesh::create_cube() {
         bgfx::createVertexBuffer(bgfx::makeRef(&m_vertexLayout[0], sizeof(m_vertexLayout[0]) * m_vertexLayout.size()),
                                  VertexLayout::s_meshVertexLayout);
 }
+
+void Mesh::generate_default_asset() {}
 
 }  // namespace components
 }  // namespace knot

--- a/core/src/mesh.cpp
+++ b/core/src/mesh.cpp
@@ -36,7 +36,7 @@ void Mesh::load_mesh(const std::string& localTexturePath) {
 }
 
 void Mesh::create_cube() {
-    std::vector<int16_t> tempIndex = {
+    std::vector<unsigned int> tempIndex = {
         0,  2,  1,  1,  2,  3,  4,  5,  6,  5,  7,  6,
 
         8,  10, 9,  9,  10, 11, 12, 13, 14, 13, 15, 14,
@@ -179,6 +179,7 @@ bool Mesh::internal_load_obj(const std::string& fileName) {
 
         log::info("finished Reading : {}", fileName);
 
+        mVertices.resize(vertexIndices.size());
         for (unsigned int i = 0; i < vertexIndices.size(); i++) {
             Vertex meshVertex;
             if (tempVertices.size() > 0) {
@@ -201,22 +202,12 @@ bool Mesh::internal_load_obj(const std::string& fileName) {
     }
 
     VertexLayout::init();
-    std::vector<int16_t> tempIndex;
-    int ind = 0;
     for (auto v : mVertices) {
-        log::info("U : {} , V : {}", (int16_t)v.texCoords.x, (int16_t)v.texCoords.y);
-        tempIndex.emplace_back(ind);
         m_vertexLayout.emplace_back(VertexLayout{v.position.x, v.position.y, v.position.z,
                                                  encode_normal_rgba8(v.normal.x, v.normal.y, v.normal.z), 0,
                                                  v.texCoords.x, v.texCoords.y});
-        ind++;
     }
-
-    m_indexBuffer = std::make_shared<IndexBuffer>();
-    m_indexBuffer->set_index_buffer(tempIndex);
-
-    m_ibh = bgfx::createIndexBuffer(bgfx::makeRef(&m_indexBuffer->get_index_start(), m_indexBuffer->get_memory_size()));
-
+    m_ibh = BGFX_INVALID_HANDLE;
     m_vbh =
         bgfx::createVertexBuffer(bgfx::makeRef(&m_vertexLayout[0], sizeof(m_vertexLayout[0]) * m_vertexLayout.size()),
                                  VertexLayout::s_meshVertexLayout);

--- a/core/src/mesh.cpp
+++ b/core/src/mesh.cpp
@@ -5,8 +5,8 @@
 namespace knot {
 namespace components {
 
-Mesh::Mesh() : Asset{AssetType::MESH, "", "fallbackMesh"} {}
-Mesh::Mesh(const std::string& path) : Asset{AssetType::MESH, path, "fallbackMesh"} {}
+Mesh::Mesh() : Asset{AssetType::Mesh, "", "fallbackMesh"} {}
+Mesh::Mesh(const std::string& path) : Asset{AssetType::Mesh, path, "fallbackMesh"} {}
 
 Mesh::~Mesh() {}
 

--- a/core/src/mesh.cpp
+++ b/core/src/mesh.cpp
@@ -18,7 +18,6 @@ void Mesh::on_destroy() {
 }
 
 void Mesh::load_mesh(const std::string& localTexturePath) {
-
     std::string fullPath = PATH_MODELS + localTexturePath;
     std::filesystem::path fs_path = std::filesystem::path(fullPath);
     bgfx::TextureHandle handle = BGFX_INVALID_HANDLE;

--- a/core/src/mesh.cpp
+++ b/core/src/mesh.cpp
@@ -1,6 +1,7 @@
 #include <knoting/log.h>
 #include <knoting/mesh.h>
 #include <filesystem>
+#include <fstream>
 
 namespace knot {
 namespace components {
@@ -10,7 +11,10 @@ Mesh::Mesh(const std::string& path) : Asset{AssetType::Mesh, path, "fallbackMesh
 
 Mesh::~Mesh() {}
 
-void Mesh::on_awake() {}
+void Mesh::on_awake() {
+    //    create_cube();
+    // internal_load_obj("TheStanfordDragon_83k.obj");
+}
 
 void Mesh::on_destroy() {
     bgfx::destroy(m_vbh);
@@ -24,6 +28,7 @@ void Mesh::load_mesh(const std::string& localTexturePath) {
 
     if (std::filesystem::exists(fs_path)) {
         log::debug("file loaded at : " + fullPath);
+        internal_load_obj(fullPath);
 
     } else {
         log::error("file : " + fullPath + " does not exist");
@@ -31,7 +36,7 @@ void Mesh::load_mesh(const std::string& localTexturePath) {
 }
 
 void Mesh::create_cube() {
-    std::vector<uint16_t> tempIndex = {
+    std::vector<int16_t> tempIndex = {
         0,  2,  1,  1,  2,  3,  4,  5,  6,  5,  7,  6,
 
         8,  10, 9,  9,  10, 11, 12, 13, 14, 13, 15, 14,
@@ -78,6 +83,159 @@ void Mesh::create_cube() {
 }
 
 void Mesh::generate_default_asset() {}
+
+std::vector<std::string> split(std::string s, std::string t) {
+    std::vector<std::string> res;
+    while (1) {
+        int pos = s.find(t);
+        if (pos == -1) {
+            res.push_back(s);
+            break;
+        }
+        res.push_back(s.substr(0, pos));
+        s = s.substr(pos + 1, s.size() - pos - 1);
+    }
+    return res;
+}
+
+bool Mesh::internal_load_obj(const std::string& fileName) {
+    std::vector<unsigned int> vertexIndices, uvIndices, normalIndices;
+    std::vector<glm::vec3> tempVertices;
+    std::vector<glm::vec2> tempUVs;
+    std::vector<glm::vec3> tempNormals;
+
+    if (fileName.find(".obj") != std::string::npos) {
+        std::ifstream fin(fileName, std::ios::in);
+        if (!fin) {
+            log::error("cant open file {}", fileName);
+            return false;
+        }
+
+        log::info("loading file {}", fileName);
+
+        std::string lineBuffer;
+        while (std::getline(fin, lineBuffer)) {
+            std::stringstream ss(lineBuffer);
+            std::string cmd;
+            ss >> cmd;
+
+            if (cmd == "v") {
+                glm::vec3 vertex;
+                int dim = 0;
+                while (dim < 3 && ss >> vertex[dim]) {
+                    dim++;
+                }
+                tempVertices.push_back(vertex);
+
+            } else if (cmd == "vt") {
+                glm::vec2 uv;
+                int dim = 0;
+                while (dim < 2 && ss >> uv[dim]) {
+                    dim++;
+                }
+                tempUVs.push_back(uv);
+
+            } else if (cmd == "vn") {
+                glm::vec3 normal;
+                int dim = 0;
+                while (dim < 3 && ss >> normal[dim]) {
+                    dim++;
+                }
+
+                normal = glm::normalize(normal);
+                tempNormals.push_back(normal);
+
+            } else if (cmd == "f") {
+                std::string faceData;
+                int vertexIndex, uvIndex, normalIndex;  // v/vt/vn
+
+                while (ss >> faceData) {
+                    std::vector<std::string> data = split(faceData, "/");
+                    // vertex index
+                    if (data[0].size() > 0) {
+                        sscanf_s(data[0].c_str(), "%d", &vertexIndex);
+                        vertexIndices.push_back(vertexIndex);
+                    }
+                    // if the face vertex has a texture coord index
+                    if (data.size() >= 1) {
+                        if (data[1].size() > 0) {
+                            sscanf_s(data[1].c_str(), "%d", &uvIndex);
+                            uvIndices.push_back(uvIndex);
+                        }
+                    }
+                    // does the face vertex have a normal index
+                    if (data.size() >= 2) {
+                        if (data[2].size() > 0) {
+                            sscanf_s(data[2].c_str(), "%d", &normalIndex);
+                            normalIndices.push_back(normalIndex);
+                        }
+                    }
+                }
+            }
+        }
+
+        // close file
+        fin.close();
+
+        log::info("finished Reading : {}", fileName);
+
+        for (unsigned int i = 0; i < vertexIndices.size(); i++) {
+            Vertex meshVertex;
+            if (tempVertices.size() > 0) {
+                glm::vec3 vertex = tempVertices[vertexIndices[i] - 1];
+                meshVertex.position = vertex;
+            }
+
+            if (tempNormals.size() > 0) {
+                glm::vec3 normal = tempNormals[normalIndices[i] - 1];
+                meshVertex.normal = normal;
+            }
+
+            if (tempUVs.size() > 0) {
+                glm::vec2 uv = tempUVs[uvIndices[i] - 1];
+                meshVertex.texCoords = uv;
+            }
+
+            mVertices.push_back(meshVertex);
+        }
+    }
+
+    VertexLayout::init();
+    std::vector<int16_t> tempIndex;
+    int ind = 0;
+    for (auto v : mVertices) {
+        log::info("U : {} , V : {}", (int16_t)v.texCoords.x,(int16_t)v.texCoords.y);
+        tempIndex.emplace_back(ind);
+        m_vertexLayout.emplace_back(
+            VertexLayout{
+                v.position.x,
+                v.position.y,
+                v.position.z,
+                encode_normal_rgba8(v.normal.x, v.normal.y, v.normal.z),
+                0,
+                (int16_t)v.texCoords.x,
+                (int16_t)v.texCoords.y
+            }
+        );
+        ind++;
+    }
+//    for (auto buffer : mVertices) {
+//        log::info("POS : x: {} , y: {} , z: {}", buffer.position.x, buffer.position.y, buffer.position.z);
+//        log::info("NRM : {},{},{}", buffer.normal.x, buffer.normal.y, buffer.normal.z);
+//        log::info("UV : u : {} , v : {}", buffer.texCoords.x, buffer.texCoords.y);
+//    }
+
+    m_indexBuffer = std::make_shared<IndexBuffer>();
+    m_indexBuffer->set_index_buffer(tempIndex);
+
+    m_ibh = bgfx::createIndexBuffer(bgfx::makeRef(&m_indexBuffer->get_index_start(), m_indexBuffer->get_memory_size()));
+
+    m_vbh = bgfx::createVertexBuffer(bgfx::makeRef(&m_vertexLayout[0], sizeof(m_vertexLayout[0]) * m_vertexLayout.size()),
+                                 VertexLayout::s_meshVertexLayout);
+    log::debug("init buffers {}", fileName);
+
+    return true;
+}
 
 }  // namespace components
 }  // namespace knot

--- a/core/src/model_loader.cpp
+++ b/core/src/model_loader.cpp
@@ -1,0 +1,4 @@
+#include <knoting/asset_loaders/model_loader.h>
+namespace knot{
+
+}

--- a/core/src/model_loader.cpp
+++ b/core/src/model_loader.cpp
@@ -1,4 +1,2 @@
 #include <knoting/asset_loaders/model_loader.h>
-namespace knot{
-
-}
+namespace knot {}

--- a/core/src/shader_program.cpp
+++ b/core/src/shader_program.cpp
@@ -7,8 +7,8 @@
 namespace knot {
 namespace components {
 
-ShaderProgram::ShaderProgram() : Asset{AssetType::Shader, "", "fallbackShader"} {}
-ShaderProgram::ShaderProgram(const std::string& path) : Asset{AssetType::Shader, path, "fallbackShader"} {}
+ShaderProgram::ShaderProgram() : Asset{AssetType::Shader, ""} {}
+ShaderProgram::ShaderProgram(const std::string& path) : Asset{AssetType::Shader, path} {}
 ShaderProgram::~ShaderProgram() {}
 
 void ShaderProgram::on_destroy() {}

--- a/core/src/shader_program.cpp
+++ b/core/src/shader_program.cpp
@@ -7,8 +7,8 @@
 namespace knot {
 namespace components {
 
-ShaderProgram::ShaderProgram() : Asset{AssetType::SHADER, "", "fallbackShader"} {}
-ShaderProgram::ShaderProgram(const std::string& path) : Asset{AssetType::SHADER, path, "fallbackShader"} {}
+ShaderProgram::ShaderProgram() : Asset{AssetType::Shader, "", "fallbackShader"} {}
+ShaderProgram::ShaderProgram(const std::string& path) : Asset{AssetType::Shader, path, "fallbackShader"} {}
 ShaderProgram::~ShaderProgram() {}
 
 void ShaderProgram::on_destroy() {}

--- a/core/src/shader_program.cpp
+++ b/core/src/shader_program.cpp
@@ -7,7 +7,8 @@
 namespace knot {
 namespace components {
 
-ShaderProgram::ShaderProgram() {}
+ShaderProgram::ShaderProgram() : Asset{AssetType::SHADER, ""} {}
+ShaderProgram::ShaderProgram(const std::string& path) : Asset{AssetType::SHADER, path} {}
 ShaderProgram::~ShaderProgram() {}
 
 void ShaderProgram::on_destroy() {}

--- a/core/src/shader_program.cpp
+++ b/core/src/shader_program.cpp
@@ -7,8 +7,8 @@
 namespace knot {
 namespace components {
 
-ShaderProgram::ShaderProgram() : Asset{AssetType::SHADER, ""} {}
-ShaderProgram::ShaderProgram(const std::string& path) : Asset{AssetType::SHADER, path} {}
+ShaderProgram::ShaderProgram() : Asset{AssetType::SHADER, "", "fallbackShader"} {}
+ShaderProgram::ShaderProgram(const std::string& path) : Asset{AssetType::SHADER, path, "fallbackShader"} {}
 ShaderProgram::~ShaderProgram() {}
 
 void ShaderProgram::on_destroy() {}
@@ -99,6 +99,7 @@ std::string ShaderProgram::get_cross_platform_path(const std::string& folderName
     shaderPath.append(fileName);
     return shaderPath;
 }
+void ShaderProgram::generate_default_asset() {}
 
 }  // namespace components
 }  // namespace knot

--- a/core/src/spot_light.cpp
+++ b/core/src/spot_light.cpp
@@ -1,0 +1,13 @@
+#include <knoting/spot_light.h>
+
+namespace knot {
+namespace components {
+
+SpotLight::SpotLight() {}
+SpotLight::~SpotLight() {}
+
+void SpotLight::on_awake() {}
+void SpotLight::on_destroy() {}
+
+}  // namespace components
+}  // namespace knot

--- a/core/src/texture.cpp
+++ b/core/src/texture.cpp
@@ -50,9 +50,9 @@ void Texture::load_texture_2d(const std::string& path, bool usingMipMaps, bool u
 
     if (usingAnisotropicFiltering) {
         textureFlags =
-            BGFX_SAMPLER_U_CLAMP | BGFX_SAMPLER_V_CLAMP | BGFX_SAMPLER_MIN_ANISOTROPIC | BGFX_SAMPLER_MAG_ANISOTROPIC;
+            BGFX_SAMPLER_W_CLAMP | BGFX_SAMPLER_W_CLAMP | BGFX_SAMPLER_MIN_ANISOTROPIC | BGFX_SAMPLER_MAG_ANISOTROPIC;
     } else {
-        textureFlags = BGFX_SAMPLER_U_CLAMP | BGFX_SAMPLER_V_CLAMP | BGFX_SAMPLER_MIN_POINT | BGFX_SAMPLER_MAG_POINT;
+        textureFlags = BGFX_SAMPLER_W_CLAMP | BGFX_SAMPLER_W_CLAMP | BGFX_SAMPLER_MIN_POINT | BGFX_SAMPLER_MAG_POINT;
     }
 
     // TODO stbi does not support mips find a way to get mips working
@@ -100,8 +100,8 @@ bgfx::TextureHandle Texture::internal_generate_solid_texture(const vec4& color, 
     const bool mips{false};
 
     const uint32_t flags =
-        BGFX_SAMPLER_U_CLAMP |
-        BGFX_SAMPLER_V_CLAMP |
+        BGFX_SAMPLER_W_CLAMP |
+        BGFX_SAMPLER_W_CLAMP |
         BGFX_SAMPLER_MIN_POINT |
         BGFX_SAMPLER_MAG_POINT;
 

--- a/core/src/texture.cpp
+++ b/core/src/texture.cpp
@@ -6,13 +6,13 @@
 namespace knot {
 namespace components {
 
-Texture::Texture() : Asset{AssetType::TEXTURE, "", "fallbackTexture"} {}
-Texture::Texture(const std::string& path) : Asset{AssetType::TEXTURE, path, "fallbackTexture"} {}
+Texture::Texture() : Asset{AssetType::Texture, "", "fallbackTexture"} {}
+Texture::Texture(const std::string& path) : Asset{AssetType::Texture, path, "fallbackTexture"} {}
 Texture::~Texture() {}
 
 void Texture::on_awake() {
-    if (m_assetState != AssetState::FINISHED) {
-        m_assetState = AssetState::LOADING;
+    if (m_assetState != AssetState::Finished) {
+        m_assetState = AssetState::Loading;
         load_texture_2d(m_fullPath);
     }
 }
@@ -41,7 +41,7 @@ void Texture::load_texture_2d(const std::string& path, bool usingMipMaps, bool u
 
     if (!data) {
         log::error("Failed to load image: " + fullPath);
-        m_assetState = AssetState::FAILED;
+        m_assetState = AssetState::Failed;
         return;
     }
 
@@ -74,7 +74,7 @@ void Texture::load_texture_2d(const std::string& path, bool usingMipMaps, bool u
         textureFlags,
         bgfx::copy(data, img_size.x * img_size.y * channels));
 
-    m_assetState = AssetState::FINISHED;
+    m_assetState = AssetState::Finished;
 
     // clang-format on
 
@@ -131,34 +131,34 @@ bgfx::TextureHandle Texture::internal_generate_solid_texture(const vec4& color, 
     // clang-format on
 }
 void Texture::generate_default_asset() {
-    m_assetState = AssetState::LOADING;
+    m_assetState = AssetState::Loading;
     bgfx::TextureHandle textureHandle = internal_generate_solid_texture(vec4(1, 0, 1, 1), "fallbackTexture");
 
     if (!bgfx::isValid(m_textureHandle)) {
         log::error("fallbackTexture failed to be created");
         m_textureHandle = BGFX_INVALID_HANDLE;
-        m_assetState = AssetState::FAILED;
+        m_assetState = AssetState::Failed;
         return;
     }
 
     m_textureHandle = textureHandle;
-    m_assetState = AssetState::FINISHED;
+    m_assetState = AssetState::Finished;
 }
 
 void Texture::generate_solid_color_texture(const vec4& color, const std::string& name) {
-    m_assetState = AssetState::LOADING;
+    m_assetState = AssetState::Loading;
     bgfx::TextureHandle textureHandle = internal_generate_solid_texture(color, name);
 
     if (!bgfx::isValid(m_textureHandle)) {
         log::error("solid texture Name : {} - of color : [{},{},{},{}] failed to be created", name, color.r, color.g,
                    color.b, color.a);
         m_textureHandle = BGFX_INVALID_HANDLE;
-        m_assetState = AssetState::FAILED;
+        m_assetState = AssetState::Failed;
         return;
     }
 
     m_textureHandle = textureHandle;
-    m_assetState = AssetState::FINISHED;
+    m_assetState = AssetState::Finished;
 }
 }  // namespace components
 }  // namespace knot

--- a/core/src/texture.cpp
+++ b/core/src/texture.cpp
@@ -10,7 +10,9 @@ Texture::Texture() : Asset{AssetType::TEXTURE, ""} {}
 Texture::Texture(const std::string& path) : Asset{AssetType::TEXTURE, path} {}
 Texture::~Texture() {}
 
-void Texture::on_awake() {}
+void Texture::on_awake() {
+    load_texture_2d(m_fullPath);
+}
 
 void Texture::on_destroy() {
     bgfx::destroy(m_textureHandle);

--- a/core/src/texture.cpp
+++ b/core/src/texture.cpp
@@ -6,8 +6,8 @@
 namespace knot {
 namespace components {
 
-Texture::Texture() : Asset{AssetType::Texture, "", "fallbackTexture"} {}
-Texture::Texture(const std::string& path) : Asset{AssetType::Texture, path, "fallbackTexture"} {}
+Texture::Texture() : Asset{AssetType::Texture, ""} {}
+Texture::Texture(const std::string& path) : Asset{AssetType::Texture, path} {}
 Texture::~Texture() {}
 
 void Texture::on_awake() {

--- a/core/src/texture.cpp
+++ b/core/src/texture.cpp
@@ -6,7 +6,8 @@
 namespace knot {
 namespace components {
 
-Texture::Texture() {}
+Texture::Texture() : Asset{AssetType::TEXTURE, ""} {}
+Texture::Texture(const std::string& path) : Asset{AssetType::TEXTURE, path} {}
 Texture::~Texture() {}
 
 void Texture::on_awake() {}

--- a/core/src/texture.cpp
+++ b/core/src/texture.cpp
@@ -16,15 +16,14 @@ void Texture::on_awake() {
 
 void Texture::on_destroy() {
     bgfx::destroy(m_textureHandle);
+    log::info("removed texture : {}", m_fullPath);
 }
 
 void Texture::load_texture_2d(const std::string& path, bool usingMipMaps, bool usingAnisotropicFiltering) {
     std::string fullPath = PATH_TEXTURE + path;
     std::filesystem::path fs_path = fullPath;
 
-    if (exists(fs_path)) {
-        log::debug(fullPath + " - Exists");
-    } else {
+    if (!exists(fs_path)) {
         log::error(fullPath + " - does not Exist");
         m_textureHandle = BGFX_INVALID_HANDLE;
     }

--- a/core/src/texture.cpp
+++ b/core/src/texture.cpp
@@ -93,13 +93,13 @@ bgfx::TextureHandle Texture::internal_generate_solid_texture(const vec4& color, 
 
     m_fullPath = name;
 
-    const int x{2};
-    const int y{2};
-    const int rgba{4};
-    const int layers{1};
-    const bool mips{false};
+    constexpr int x = 2;
+    constexpr int y = 2;
+    constexpr int rgba = 4;
+    constexpr int layers = 1;
+    constexpr bool mips = false;
 
-    const uint32_t flags =
+    constexpr uint32_t flags =
         BGFX_SAMPLER_W_CLAMP |
         BGFX_SAMPLER_W_CLAMP |
         BGFX_SAMPLER_MIN_POINT |

--- a/core/src/window.cpp
+++ b/core/src/window.cpp
@@ -39,7 +39,6 @@ Window::Window(int width, int height, std::string title, Engine& engine)
     // To avoid creating a render thread we need to call renderFrame() manually
     bgfx::renderFrame();
     bgfx::Init init;
-    
 #if BX_PLATFORM_WINDOWS
     init.platformData.nwh = glfwGetWin32Window(m_window);
 #elif BX_PLATFORM_LINUX || BX_PLATFORM_BSD

--- a/core/src/window.cpp
+++ b/core/src/window.cpp
@@ -39,9 +39,7 @@ Window::Window(int width, int height, std::string title, Engine& engine)
     // To avoid creating a render thread we need to call renderFrame() manually
     bgfx::renderFrame();
     bgfx::Init init;
-
-    init.type = bgfx::RendererType::Vulkan;
-
+    
 #if BX_PLATFORM_WINDOWS
     init.platformData.nwh = glfwGetWin32Window(m_window);
 #elif BX_PLATFORM_LINUX || BX_PLATFORM_BSD

--- a/core/src/window.cpp
+++ b/core/src/window.cpp
@@ -40,7 +40,7 @@ Window::Window(int width, int height, std::string title, Engine& engine)
     bgfx::renderFrame();
     bgfx::Init init;
 
-    init.type = bgfx::RendererType::OpenGL;
+    init.type = bgfx::RendererType::Vulkan;
 
 #if BX_PLATFORM_WINDOWS
     init.platformData.nwh = glfwGetWin32Window(m_window);

--- a/res/misc/dragon.obj
+++ b/res/misc/dragon.obj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35621b4668e6650360a24e4f8474dad196dd7783cb1a39a17d85021bc103a41c
+size 7983947

--- a/res/misc/light.obj
+++ b/res/misc/light.obj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:236f03089cd28aaa98c15c4821b12d9c8a70b1c42061044be00152450508f56f
+size 7193

--- a/res/misc/uv_cube.obj
+++ b/res/misc/uv_cube.obj
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:97c158350c5b7a2298c6c2f91bf4727df43dd35ebc0b2456a58271019d7ba0cf
+size 1143

--- a/res/textures/oldiron/OldIron01_1K_BaseColor.png
+++ b/res/textures/oldiron/OldIron01_1K_BaseColor.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8571dd3d218f75ca60ab67a406a6cbbb4521bfeb93502c96f9d082c1ff534cfe
+size 2196249

--- a/res/textures/oldiron/OldIron01_1K_Height.png
+++ b/res/textures/oldiron/OldIron01_1K_Height.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4cae2777a024953d009d5dfa83225d2e866dc2ad8a0dc965efd4ca653f60ae1a
+size 1188072

--- a/res/textures/oldiron/OldIron01_1K_Metallic.png
+++ b/res/textures/oldiron/OldIron01_1K_Metallic.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7fa668d3d207f02825f106678873e530c0aecd8d5d9bc3baebe1d6466afa25d4
+size 1491654

--- a/res/textures/oldiron/OldIron01_1K_Normal.png
+++ b/res/textures/oldiron/OldIron01_1K_Normal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4df2cb97c7fd2c6cf42afd8331e6cec84f40729cf1ff4b32b07845f96530443
+size 2706087

--- a/res/textures/oldiron/OldIron01_1K_Roughness.png
+++ b/res/textures/oldiron/OldIron01_1K_Roughness.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:46970f179327315a40645f43975ea95767ec02c3fa2b24e2433e4cd346107a58
+size 526621

--- a/untie/src/untie.cpp
+++ b/untie/src/untie.cpp
@@ -1,15 +1,10 @@
 #include "untie.h"
-
+#include <knoting/components.h>
 #include <knoting/game_object.h>
 #include <knoting/instance_mesh.h>
 #include <knoting/log.h>
-#include <knoting/mesh.h>
 #include <knoting/scene.h>
-#include <knoting/texture.h>
 #include <knoting/spot_light.h>
-
-#include <knoting/components.h>
-#include <knoting/scene.h>
 
 #include <iostream>
 

--- a/untie/src/untie.cpp
+++ b/untie/src/untie.cpp
@@ -30,7 +30,12 @@ Untie::Untie() {
         cubeObj.get_component<components::Transform>().set_scale(glm::vec3(15.0f, 1.0f, 15.0f));
         auto& mesh = cubeObj.add_component<components::Mesh>();
         mesh.create_cube();
-        auto material = cubeObj.add_component<components::Material>();
+        auto& material = cubeObj.add_component<components::Material>();
+        material.set_texture_slot_path(TextureType::Albedo,"UV_Grid_test.png");
+        material.set_texture_slot_path(TextureType::Normal,"normal_tiles_1k.png");
+        material.set_texture_slot_path(TextureType::Metallic,"");
+        material.set_texture_slot_path(TextureType::Roughness,"");
+        material.set_texture_slot_path(TextureType::Occlusion,"");
     }
     {
         auto cubeObj = scene.create_game_object("cube_1");
@@ -38,6 +43,11 @@ Untie::Untie() {
         auto& mesh = cubeObj.add_component<components::Mesh>();
         mesh.create_cube();
         auto material = cubeObj.add_component<components::Material>();
+        material.set_texture_slot_path(TextureType::Albedo,"UV_Grid_test.png");
+        material.set_texture_slot_path(TextureType::Normal,"normal_tiles_1k.png");
+        material.set_texture_slot_path(TextureType::Metallic,"");
+        material.set_texture_slot_path(TextureType::Roughness,"");
+        material.set_texture_slot_path(TextureType::Occlusion,"");
     }
     {
         auto cubeObj = scene.create_game_object("ground");
@@ -45,6 +55,11 @@ Untie::Untie() {
         auto& mesh = cubeObj.add_component<components::Mesh>();
         mesh.create_cube();
         auto material = cubeObj.add_component<components::Material>();
+        material.set_texture_slot_path(TextureType::Albedo,"UV_Grid_test.png");
+        material.set_texture_slot_path(TextureType::Normal,"normal_tiles_1k.png");
+        material.set_texture_slot_path(TextureType::Metallic,"");
+        material.set_texture_slot_path(TextureType::Roughness,"");
+        material.set_texture_slot_path(TextureType::Occlusion,"");
     }
 }
 

--- a/untie/src/untie.cpp
+++ b/untie/src/untie.cpp
@@ -6,6 +6,7 @@
 #include <knoting/mesh.h>
 #include <knoting/scene.h>
 #include <knoting/texture.h>
+#include <knoting/spot_light.h>
 
 #include <knoting/components.h>
 #include <knoting/scene.h>
@@ -23,6 +24,38 @@ Untie::Untie() {
         auto editorCamera = scene.create_game_object("camera");
         auto& cam = editorCamera.add_component<components::EditorCamera>();
         editorCamera.get_component<components::Transform>().set_position(glm::vec3(-10.0f, 15.0f, -30.0f));
+    }
+    {
+        auto light = scene.create_game_object("light_0");
+        auto& spotLight = light.add_component<components::SpotLight>();
+        spotLight.set_color(vec3(1.0f, 0.7f, 0.2f));
+        spotLight.set_outer_radius(17.0f);
+        spotLight.set_inner_radius(0.5f);
+        light.get_component<components::Transform>().set_position(glm::vec3(2.3897731, 14.570069, -10));
+    }
+    {
+        auto light = scene.create_game_object("light_1");
+        auto& spotLight = light.add_component<components::SpotLight>();
+        spotLight.set_color(vec3(0.7f, 0.2f, 1.0f));
+        spotLight.set_outer_radius(17.0f);
+        spotLight.set_inner_radius(0.5f);
+        light.get_component<components::Transform>().set_position(glm::vec3(10.351221, -13.538474, -10));
+    }
+    {
+        auto light = scene.create_game_object("light_2");
+        auto& spotLight = light.add_component<components::SpotLight>();
+        spotLight.set_color(vec3(0.2f, 1.0f, 0.7f));
+        spotLight.set_outer_radius(17.0f);
+        spotLight.set_inner_radius(0.5f);
+        light.get_component<components::Transform>().set_position(glm::vec3(-14.905335, 6.3970194, -10));
+    }
+    {
+        auto light = scene.create_game_object("light_3");
+        auto& spotLight = light.add_component<components::SpotLight>();
+        spotLight.set_color(vec3(1.0f, 0.4f, 0.2f));
+        spotLight.set_outer_radius(17.0f);
+        spotLight.set_inner_radius(0.5f);
+        light.get_component<components::Transform>().set_position(glm::vec3(7.6706734, 3.631392, -10));
     }
     {
         auto cubeObj = scene.create_game_object("loaded_cube");

--- a/untie/src/untie.cpp
+++ b/untie/src/untie.cpp
@@ -33,7 +33,7 @@ Untie::Untie() {
         mesh.create_cube();
 
         auto material = components::Material();
-        material.set_texture_slot_path(TextureType::Albedo, "UV_Grid_test.png");
+        material.set_texture_slot_path(TextureType::Albedo, "");
         material.set_texture_slot_path(TextureType::Normal, "normal_tiles_1k.png");
         material.set_texture_slot_path(TextureType::Metallic, "b");
         material.set_texture_slot_path(TextureType::Roughness, "b2");
@@ -41,38 +41,38 @@ Untie::Untie() {
 
         cubeObj.add_component<components::Material>(material);
     }
-    {
-        auto cubeObj = scene.create_game_object("cube_1");
-        cubeObj.get_component<components::Transform>().set_position(glm::vec3(0.0f, 3.0f, 0.0f));
-
-        auto& mesh = cubeObj.add_component<components::Mesh>();
-        mesh.create_cube();
-
-        auto material = components::Material();
-        material.set_texture_slot_path(TextureType::Albedo, "UV_Grid_test.png");
-        material.set_texture_slot_path(TextureType::Normal, "normal_tiles_1k.png");
-        material.set_texture_slot_path(TextureType::Metallic, "b");
-        material.set_texture_slot_path(TextureType::Roughness, "b2");
-        material.set_texture_slot_path(TextureType::Occlusion, "b3");
-
-        cubeObj.add_component<components::Material>(material);
-    }
-    {
-        auto cubeObj = scene.create_game_object("ground");
-        cubeObj.get_component<components::Transform>().set_position(glm::vec3(1.0f, 7.0f, 1.0f));
-
-        auto& mesh = cubeObj.add_component<components::Mesh>();
-        mesh.create_cube();
-
-        auto material = components::Material();
-        material.set_texture_slot_path(TextureType::Albedo, "UV_Grid_test.png");
-        material.set_texture_slot_path(TextureType::Normal, "normal_tiles_1k.png");
-        material.set_texture_slot_path(TextureType::Metallic, "b");
-        material.set_texture_slot_path(TextureType::Roughness, "b2");
-        material.set_texture_slot_path(TextureType::Occlusion, "b3");
-
-        cubeObj.add_component<components::Material>(material);
-    }
+//    {
+//        auto cubeObj = scene.create_game_object("cube_1");
+//        cubeObj.get_component<components::Transform>().set_position(glm::vec3(0.0f, 3.0f, 0.0f));
+//
+//        auto& mesh = cubeObj.add_component<components::Mesh>();
+//        mesh.create_cube();
+//
+//        auto material = components::Material();
+//        material.set_texture_slot_path(TextureType::Albedo, "UV_Grid_test.png");
+//        material.set_texture_slot_path(TextureType::Normal, "normal_tiles_1k.png");
+//        material.set_texture_slot_path(TextureType::Metallic, "b");
+//        material.set_texture_slot_path(TextureType::Roughness, "b2");
+//        material.set_texture_slot_path(TextureType::Occlusion, "b3");
+//
+//        cubeObj.add_component<components::Material>(material);
+//    }
+//    {
+//        auto cubeObj = scene.create_game_object("ground");
+//        cubeObj.get_component<components::Transform>().set_position(glm::vec3(1.0f, 7.0f, 1.0f));
+//
+//        auto& mesh = cubeObj.add_component<components::Mesh>();
+//        mesh.create_cube();
+//
+//        auto material = components::Material();
+//        material.set_texture_slot_path(TextureType::Albedo, "UV_Grid_test.png");
+//        material.set_texture_slot_path(TextureType::Normal, "normal_tiles_1k.png");
+//        material.set_texture_slot_path(TextureType::Metallic, "b");
+//        material.set_texture_slot_path(TextureType::Roughness, "b2");
+//        material.set_texture_slot_path(TextureType::Occlusion, "b3");
+//
+//        cubeObj.add_component<components::Material>(material);
+//    }
 }
 
 void Untie::run() {

--- a/untie/src/untie.cpp
+++ b/untie/src/untie.cpp
@@ -24,32 +24,12 @@ Untie::Untie() {
         auto& cam = editorCamera.add_component<components::EditorCamera>();
         editorCamera.get_component<components::Transform>().set_position(glm::vec3(-10.0f, 15.0f, -30.0f));
     }
-
     {
-        //        auto cubeObj = scene.create_game_object("cube_0");
-        //        cubeObj.get_component<components::Transform>().set_position(glm::vec3(0, -10, 0));
-        //        cubeObj.get_component<components::Transform>().set_scale(glm::vec3(15.0f, 1.0f, 15.0f));
-        //
-        //        auto& mesh = cubeObj.add_component<components::Mesh>();
-        //        mesh.create_cube();
-        //
-        //        auto material = components::Material();
-        //        material.set_texture_slot_path(TextureType::Albedo, "UV_Grid_test.png");
-        //        material.set_texture_slot_path(TextureType::Normal, "normal_tiles_1k.png");
-        //        material.set_texture_slot_path(TextureType::Metallic, "whiteTexture");
-        //        material.set_texture_slot_path(TextureType::Roughness, "whiteTexture");
-        //        material.set_texture_slot_path(TextureType::Occlusion, "whiteTexture");
-        //
-        //        cubeObj.add_component<components::Material>(material);
-    } {
         auto cubeObj = scene.create_game_object("loaded_cube");
         cubeObj.get_component<components::Transform>().set_position(glm::vec3(-5.0f, 0.0f, -10.0f));
         cubeObj.get_component<components::Transform>().set_scale(glm::vec3(15, 1, 15));
         cubeObj.get_component<components::Transform>().set_rotation_euler(glm::vec3(0, 45, 0));
-        cubeObj.add_component<components::Mesh>("uv_cube.obj");
-         cubeObj.add_component<InstanceMesh>("uv_cube.obj");
-
-        //        mesh.load_mesh("uv_cube.obj");
+        cubeObj.add_component<InstanceMesh>("uv_cube.obj");
 
         auto material = components::Material();
         material.set_texture_slot_path(TextureType::Albedo, "UV_Grid_test.png");
@@ -57,43 +37,84 @@ Untie::Untie() {
         material.set_texture_slot_path(TextureType::Metallic, "whiteTexture");
         material.set_texture_slot_path(TextureType::Roughness, "whiteTexture");
         material.set_texture_slot_path(TextureType::Occlusion, "whiteTexture");
+        cubeObj.add_component<components::Material>(material);
+    }
+    {
+        auto cubeObj = scene.create_game_object("loaded_dragon");
+        cubeObj.get_component<components::Transform>().set_position(glm::vec3(-5.0f, 1.0f, -10.0f));
+        cubeObj.get_component<components::Transform>().set_scale(glm::vec3(5, 5, 5));
+        cubeObj.get_component<components::Transform>().set_rotation_euler(glm::vec3(0, 180, 0));
+        cubeObj.add_component<InstanceMesh>("dragon.obj");
 
+        auto material = components::Material();
+        material.set_texture_slot_path(TextureType::Albedo, "oldiron/OldIron01_1K_BaseColor.png");
+        material.set_texture_slot_path(TextureType::Normal, "oldiron/OldIron01_1K_Normal.png");
+        material.set_texture_slot_path(TextureType::Metallic, "whiteTexture");
+        material.set_texture_slot_path(TextureType::Roughness, "whiteTexture");
+        material.set_texture_slot_path(TextureType::Occlusion, "whiteTexture");
         cubeObj.add_component<components::Material>(material);
     }
 
-    //        {
-    //            auto cubeObj = scene.create_game_object("stanford");
-    //            cubeObj.get_component<components::Transform>().set_scale(glm::vec3(5));
-    //            cubeObj.get_component<components::Transform>().set_position(glm::vec3(-5, 2.0f, -10.0f));
-    //            cubeObj.get_component<components::Transform>().set_rotation_euler(glm::vec3(0, 210, 0));
-    //
-    //            auto& mesh = cubeObj.add_component<components::Mesh>("dragon.obj");
-    //
-    //            auto material = components::Material();
-    //            material.set_texture_slot_path(TextureType::Albedo, "oldiron/OldIron01_1K_BaseColor.png");
-    //            material.set_texture_slot_path(TextureType::Normal, "oldiron/OldIron01_1K_Normal.png");
-    //            material.set_texture_slot_path(TextureType::Metallic, "whiteTexture");
-    //            material.set_texture_slot_path(TextureType::Roughness, "whiteTexture");
-    //            material.set_texture_slot_path(TextureType::Occlusion, "whiteTexture");
-    //
-    //            cubeObj.add_component<components::Material>(material);
-    //        }
-    //    {
-    //        auto cubeObj = scene.create_game_object("ground");
-    //        cubeObj.get_component<components::Transform>().set_position(glm::vec3(1.0f, 7.0f, 1.0f));
-    //
-    //        auto& mesh = cubeObj.add_component<components::Mesh>();
-    //        mesh.create_cube();
-    //
-    //        auto material = components::Material();
-    //        material.set_texture_slot_path(TextureType::Albedo, "UV_Grid_test.png");
-    //        material.set_texture_slot_path(TextureType::Normal, "normal_tiles_1k.png");
-    //        material.set_texture_slot_path(TextureType::Metallic, "whiteTexture");
-    //        material.set_texture_slot_path(TextureType::Roughness, "whiteTexture");
-    //        material.set_texture_slot_path(TextureType::Occlusion, "whiteTexture");
-    //
-    //        cubeObj.add_component<components::Material>(material);
-    //    }
+    {
+        auto cubeObj = scene.create_game_object("loaded_dragon");
+        cubeObj.get_component<components::Transform>().set_position(glm::vec3(-5.0f + 5, 1.0f, -10.0f - 5));
+        cubeObj.get_component<components::Transform>().set_scale(glm::vec3(3, 3, 3));
+        cubeObj.get_component<components::Transform>().set_rotation_euler(glm::vec3(0, 240, 0));
+        cubeObj.add_component<InstanceMesh>("dragon.obj");
+
+        auto material = components::Material();
+        material.set_texture_slot_path(TextureType::Albedo, "oldiron/OldIron01_1K_BaseColor.png");
+        material.set_texture_slot_path(TextureType::Normal, "oldiron/OldIron01_1K_Normal.png");
+        material.set_texture_slot_path(TextureType::Metallic, "whiteTexture");
+        material.set_texture_slot_path(TextureType::Roughness, "whiteTexture");
+        material.set_texture_slot_path(TextureType::Occlusion, "whiteTexture");
+        cubeObj.add_component<components::Material>(material);
+    }
+    {
+        auto cubeObj = scene.create_game_object("loaded_dragon");
+        cubeObj.get_component<components::Transform>().set_position(glm::vec3(-5.0f - 5, 1.0f, -10.0f - 5));
+        cubeObj.get_component<components::Transform>().set_scale(glm::vec3(3, 3, 3));
+        cubeObj.get_component<components::Transform>().set_rotation_euler(glm::vec3(0, 160, 0));
+        cubeObj.add_component<InstanceMesh>("dragon.obj");
+
+        auto material = components::Material();
+        material.set_texture_slot_path(TextureType::Albedo, "oldiron/OldIron01_1K_BaseColor.png");
+        material.set_texture_slot_path(TextureType::Normal, "oldiron/OldIron01_1K_Normal.png");
+        material.set_texture_slot_path(TextureType::Metallic, "whiteTexture");
+        material.set_texture_slot_path(TextureType::Roughness, "whiteTexture");
+        material.set_texture_slot_path(TextureType::Occlusion, "whiteTexture");
+        cubeObj.add_component<components::Material>(material);
+    }
+    {
+        auto cubeObj = scene.create_game_object("loaded_dragon");
+        cubeObj.get_component<components::Transform>().set_position(glm::vec3(-5.0f, 1.0f, -10.0f - 7));
+        cubeObj.get_component<components::Transform>().set_scale(glm::vec3(3, 3, 3));
+        cubeObj.get_component<components::Transform>().set_rotation_euler(glm::vec3(0, 45, 0));
+        cubeObj.add_component<InstanceMesh>("dragon.obj");
+
+        auto material = components::Material();
+        material.set_texture_slot_path(TextureType::Albedo, "oldiron/OldIron01_1K_BaseColor.png");
+        material.set_texture_slot_path(TextureType::Normal, "oldiron/OldIron01_1K_Normal.png");
+        material.set_texture_slot_path(TextureType::Metallic, "whiteTexture");
+        material.set_texture_slot_path(TextureType::Roughness, "whiteTexture");
+        material.set_texture_slot_path(TextureType::Occlusion, "whiteTexture");
+        cubeObj.add_component<components::Material>(material);
+    }
+    {
+        auto cubeObj = scene.create_game_object("loaded_dragon");
+        cubeObj.get_component<components::Transform>().set_position(glm::vec3(-5.0f - 8, 1.0f, -10.0f + 2));
+        cubeObj.get_component<components::Transform>().set_scale(glm::vec3(3, 3, 3));
+        cubeObj.get_component<components::Transform>().set_rotation_euler(glm::vec3(0, 90, 0));
+        cubeObj.add_component<InstanceMesh>("dragon.obj");
+
+        auto material = components::Material();
+        material.set_texture_slot_path(TextureType::Albedo, "oldiron/OldIron01_1K_BaseColor.png");
+        material.set_texture_slot_path(TextureType::Normal, "oldiron/OldIron01_1K_Normal.png");
+        material.set_texture_slot_path(TextureType::Metallic, "whiteTexture");
+        material.set_texture_slot_path(TextureType::Roughness, "whiteTexture");
+        material.set_texture_slot_path(TextureType::Occlusion, "whiteTexture");
+        cubeObj.add_component<components::Material>(material);
+    }
 }
 
 void Untie::run() {

--- a/untie/src/untie.cpp
+++ b/untie/src/untie.cpp
@@ -33,11 +33,11 @@ Untie::Untie() {
         mesh.create_cube();
 
         auto material = components::Material();
-        material.set_texture_slot_path(TextureType::Albedo, "");
+        material.set_texture_slot_path(TextureType::Albedo, "UV_Grid_test.png");
         material.set_texture_slot_path(TextureType::Normal, "normal_tiles_1k.png");
-        material.set_texture_slot_path(TextureType::Metallic, "b");
-        material.set_texture_slot_path(TextureType::Roughness, "b2");
-        material.set_texture_slot_path(TextureType::Occlusion, "b3");
+        material.set_texture_slot_path(TextureType::Metallic, "whiteTexture");
+        material.set_texture_slot_path(TextureType::Roughness, "whiteTexture");
+        material.set_texture_slot_path(TextureType::Occlusion, "whiteTexture");
 
         cubeObj.add_component<components::Material>(material);
     }
@@ -51,9 +51,9 @@ Untie::Untie() {
         auto material = components::Material();
         material.set_texture_slot_path(TextureType::Albedo, "UV_Grid_test.png");
         material.set_texture_slot_path(TextureType::Normal, "normal_tiles_1k.png");
-        material.set_texture_slot_path(TextureType::Metallic, "b");
-        material.set_texture_slot_path(TextureType::Roughness, "b2");
-        material.set_texture_slot_path(TextureType::Occlusion, "b3");
+        material.set_texture_slot_path(TextureType::Metallic, "whiteTexture");
+        material.set_texture_slot_path(TextureType::Roughness, "whiteTexture");
+        material.set_texture_slot_path(TextureType::Occlusion, "whiteTexture");
 
         cubeObj.add_component<components::Material>(material);
     }
@@ -67,9 +67,9 @@ Untie::Untie() {
         auto material = components::Material();
         material.set_texture_slot_path(TextureType::Albedo, "UV_Grid_test.png");
         material.set_texture_slot_path(TextureType::Normal, "normal_tiles_1k.png");
-        material.set_texture_slot_path(TextureType::Metallic, "b");
-        material.set_texture_slot_path(TextureType::Roughness, "b2");
-        material.set_texture_slot_path(TextureType::Occlusion, "b3");
+        material.set_texture_slot_path(TextureType::Metallic, "whiteTexture");
+        material.set_texture_slot_path(TextureType::Roughness, "whiteTexture");
+        material.set_texture_slot_path(TextureType::Occlusion, "whiteTexture");
 
         cubeObj.add_component<components::Material>(material);
     }

--- a/untie/src/untie.cpp
+++ b/untie/src/untie.cpp
@@ -54,7 +54,6 @@ Untie::Untie() {
         material.set_texture_slot_path(TextureType::Occlusion, "whiteTexture");
         cubeObj.add_component<components::Material>(material);
     }
-
     {
         auto cubeObj = scene.create_game_object("loaded_dragon");
         cubeObj.get_component<components::Transform>().set_position(glm::vec3(-5.0f + 5, 1.0f, -10.0f - 5));

--- a/untie/src/untie.cpp
+++ b/untie/src/untie.cpp
@@ -41,38 +41,38 @@ Untie::Untie() {
 
         cubeObj.add_component<components::Material>(material);
     }
-//    {
-//        auto cubeObj = scene.create_game_object("cube_1");
-//        cubeObj.get_component<components::Transform>().set_position(glm::vec3(0.0f, 3.0f, 0.0f));
-//
-//        auto& mesh = cubeObj.add_component<components::Mesh>();
-//        mesh.create_cube();
-//
-//        auto material = components::Material();
-//        material.set_texture_slot_path(TextureType::Albedo, "UV_Grid_test.png");
-//        material.set_texture_slot_path(TextureType::Normal, "normal_tiles_1k.png");
-//        material.set_texture_slot_path(TextureType::Metallic, "b");
-//        material.set_texture_slot_path(TextureType::Roughness, "b2");
-//        material.set_texture_slot_path(TextureType::Occlusion, "b3");
-//
-//        cubeObj.add_component<components::Material>(material);
-//    }
-//    {
-//        auto cubeObj = scene.create_game_object("ground");
-//        cubeObj.get_component<components::Transform>().set_position(glm::vec3(1.0f, 7.0f, 1.0f));
-//
-//        auto& mesh = cubeObj.add_component<components::Mesh>();
-//        mesh.create_cube();
-//
-//        auto material = components::Material();
-//        material.set_texture_slot_path(TextureType::Albedo, "UV_Grid_test.png");
-//        material.set_texture_slot_path(TextureType::Normal, "normal_tiles_1k.png");
-//        material.set_texture_slot_path(TextureType::Metallic, "b");
-//        material.set_texture_slot_path(TextureType::Roughness, "b2");
-//        material.set_texture_slot_path(TextureType::Occlusion, "b3");
-//
-//        cubeObj.add_component<components::Material>(material);
-//    }
+    {
+        auto cubeObj = scene.create_game_object("cube_1");
+        cubeObj.get_component<components::Transform>().set_position(glm::vec3(0.0f, 3.0f, 0.0f));
+
+        auto& mesh = cubeObj.add_component<components::Mesh>();
+        mesh.create_cube();
+
+        auto material = components::Material();
+        material.set_texture_slot_path(TextureType::Albedo, "UV_Grid_test.png");
+        material.set_texture_slot_path(TextureType::Normal, "normal_tiles_1k.png");
+        material.set_texture_slot_path(TextureType::Metallic, "b");
+        material.set_texture_slot_path(TextureType::Roughness, "b2");
+        material.set_texture_slot_path(TextureType::Occlusion, "b3");
+
+        cubeObj.add_component<components::Material>(material);
+    }
+    {
+        auto cubeObj = scene.create_game_object("ground");
+        cubeObj.get_component<components::Transform>().set_position(glm::vec3(1.0f, 7.0f, 1.0f));
+
+        auto& mesh = cubeObj.add_component<components::Mesh>();
+        mesh.create_cube();
+
+        auto material = components::Material();
+        material.set_texture_slot_path(TextureType::Albedo, "UV_Grid_test.png");
+        material.set_texture_slot_path(TextureType::Normal, "normal_tiles_1k.png");
+        material.set_texture_slot_path(TextureType::Metallic, "b");
+        material.set_texture_slot_path(TextureType::Roughness, "b2");
+        material.set_texture_slot_path(TextureType::Occlusion, "b3");
+
+        cubeObj.add_component<components::Material>(material);
+    }
 }
 
 void Untie::run() {

--- a/untie/src/untie.cpp
+++ b/untie/src/untie.cpp
@@ -25,42 +25,42 @@ Untie::Untie() {
     }
 
     {
-//        auto cubeObj = scene.create_game_object("cube_0");
-//        cubeObj.get_component<components::Transform>().set_position(glm::vec3(0, -10, 0));
-//        cubeObj.get_component<components::Transform>().set_scale(glm::vec3(15.0f, 1.0f, 15.0f));
-//
-//        auto& mesh = cubeObj.add_component<components::Mesh>();
-//        mesh.create_cube();
-//
-//        auto material = components::Material();
-//        material.set_texture_slot_path(TextureType::Albedo, "UV_Grid_test.png");
-//        material.set_texture_slot_path(TextureType::Normal, "normal_tiles_1k.png");
-//        material.set_texture_slot_path(TextureType::Metallic, "whiteTexture");
-//        material.set_texture_slot_path(TextureType::Roughness, "whiteTexture");
-//        material.set_texture_slot_path(TextureType::Occlusion, "whiteTexture");
-//
-//        cubeObj.add_component<components::Material>(material);
-    }
-    {
-        auto cubeObj = scene.create_game_object("sphere_1");
-        cubeObj.get_component<components::Transform>().set_position(glm::vec3(0.0f, 4.0f, 0.0f));
+        //        auto cubeObj = scene.create_game_object("cube_0");
+        //        cubeObj.get_component<components::Transform>().set_position(glm::vec3(0, -10, 0));
+        //        cubeObj.get_component<components::Transform>().set_scale(glm::vec3(15.0f, 1.0f, 15.0f));
+        //
+        //        auto& mesh = cubeObj.add_component<components::Mesh>();
+        //        mesh.create_cube();
+        //
+        //        auto material = components::Material();
+        //        material.set_texture_slot_path(TextureType::Albedo, "UV_Grid_test.png");
+        //        material.set_texture_slot_path(TextureType::Normal, "normal_tiles_1k.png");
+        //        material.set_texture_slot_path(TextureType::Metallic, "whiteTexture");
+        //        material.set_texture_slot_path(TextureType::Roughness, "whiteTexture");
+        //        material.set_texture_slot_path(TextureType::Occlusion, "whiteTexture");
+        //
+        //        cubeObj.add_component<components::Material>(material);
+    } {
+        auto cubeObj = scene.create_game_object("loaded_cube");
+        cubeObj.get_component<components::Transform>().set_position(glm::vec3(0.0f, -5.0f, 0.0f));
+        cubeObj.get_component<components::Transform>().set_scale(glm::vec3(10.0f));
+        cubeObj.get_component<components::Transform>().set_rotation_euler(glm::vec3(0, 45, 0));
 
         auto& mesh = cubeObj.add_component<components::Mesh>();
-        mesh.load_mesh("cube.obj");
+        mesh.load_mesh("uv_cube.obj");
 
         auto material = components::Material();
-        material.set_texture_slot_path(TextureType::Albedo, "whiteTexture");
+        material.set_texture_slot_path(TextureType::Albedo, "UV_Grid_test.png");
         material.set_texture_slot_path(TextureType::Normal, "normal_tiles_1k.png");
         material.set_texture_slot_path(TextureType::Metallic, "whiteTexture");
         material.set_texture_slot_path(TextureType::Roughness, "whiteTexture");
         material.set_texture_slot_path(TextureType::Occlusion, "whiteTexture");
 
         cubeObj.add_component<components::Material>(material);
-
     }
     {
         auto cubeObj = scene.create_game_object("cube_1");
-        cubeObj.get_component<components::Transform>().set_position(glm::vec3(0.0f, 1.0f, 0.0f));
+        cubeObj.get_component<components::Transform>().set_position(glm::vec3(-4.0f, 6.0f, -4.0f));
 
         auto& mesh = cubeObj.add_component<components::Mesh>();
         mesh.create_cube();
@@ -74,22 +74,22 @@ Untie::Untie() {
 
         cubeObj.add_component<components::Material>(material);
     }
-//    {
-//        auto cubeObj = scene.create_game_object("ground");
-//        cubeObj.get_component<components::Transform>().set_position(glm::vec3(1.0f, 7.0f, 1.0f));
-//
-//        auto& mesh = cubeObj.add_component<components::Mesh>();
-//        mesh.create_cube();
-//
-//        auto material = components::Material();
-//        material.set_texture_slot_path(TextureType::Albedo, "UV_Grid_test.png");
-//        material.set_texture_slot_path(TextureType::Normal, "normal_tiles_1k.png");
-//        material.set_texture_slot_path(TextureType::Metallic, "whiteTexture");
-//        material.set_texture_slot_path(TextureType::Roughness, "whiteTexture");
-//        material.set_texture_slot_path(TextureType::Occlusion, "whiteTexture");
-//
-//        cubeObj.add_component<components::Material>(material);
-//    }
+    //    {
+    //        auto cubeObj = scene.create_game_object("ground");
+    //        cubeObj.get_component<components::Transform>().set_position(glm::vec3(1.0f, 7.0f, 1.0f));
+    //
+    //        auto& mesh = cubeObj.add_component<components::Mesh>();
+    //        mesh.create_cube();
+    //
+    //        auto material = components::Material();
+    //        material.set_texture_slot_path(TextureType::Albedo, "UV_Grid_test.png");
+    //        material.set_texture_slot_path(TextureType::Normal, "normal_tiles_1k.png");
+    //        material.set_texture_slot_path(TextureType::Metallic, "whiteTexture");
+    //        material.set_texture_slot_path(TextureType::Roughness, "whiteTexture");
+    //        material.set_texture_slot_path(TextureType::Occlusion, "whiteTexture");
+    //
+    //        cubeObj.add_component<components::Material>(material);
+    //    }
 }
 
 void Untie::run() {

--- a/untie/src/untie.cpp
+++ b/untie/src/untie.cpp
@@ -1,6 +1,7 @@
 #include "untie.h"
 
 #include <knoting/game_object.h>
+#include <knoting/instance_mesh.h>
 #include <knoting/log.h>
 #include <knoting/mesh.h>
 #include <knoting/scene.h>
@@ -45,9 +46,10 @@ Untie::Untie() {
         cubeObj.get_component<components::Transform>().set_position(glm::vec3(-5.0f, 0.0f, -10.0f));
         cubeObj.get_component<components::Transform>().set_scale(glm::vec3(15, 1, 15));
         cubeObj.get_component<components::Transform>().set_rotation_euler(glm::vec3(0, 45, 0));
+        cubeObj.add_component<components::Mesh>("uv_cube.obj");
+         cubeObj.add_component<InstanceMesh>("uv_cube.obj");
 
-        auto& mesh = cubeObj.add_component<components::Mesh>();
-        mesh.load_mesh("uv_cube.obj");
+        //        mesh.load_mesh("uv_cube.obj");
 
         auto material = components::Material();
         material.set_texture_slot_path(TextureType::Albedo, "UV_Grid_test.png");
@@ -58,24 +60,24 @@ Untie::Untie() {
 
         cubeObj.add_component<components::Material>(material);
     }
-    {
-        auto cubeObj = scene.create_game_object("stanford");
-        cubeObj.get_component<components::Transform>().set_scale(glm::vec3(5));
-        cubeObj.get_component<components::Transform>().set_position(glm::vec3(-5, 2.0f, -10.0f));
-        cubeObj.get_component<components::Transform>().set_rotation_euler(glm::vec3(0, 210, 0));
 
-        auto& mesh = cubeObj.add_component<components::Mesh>();
-        mesh.load_mesh("dragon.obj");
-
-        auto material = components::Material();
-        material.set_texture_slot_path(TextureType::Albedo, "oldiron/OldIron01_1K_BaseColor.png");
-        material.set_texture_slot_path(TextureType::Normal, "oldiron/OldIron01_1K_Normal.png");
-        material.set_texture_slot_path(TextureType::Metallic, "whiteTexture");
-        material.set_texture_slot_path(TextureType::Roughness, "whiteTexture");
-        material.set_texture_slot_path(TextureType::Occlusion, "whiteTexture");
-
-        cubeObj.add_component<components::Material>(material);
-    }
+    //        {
+    //            auto cubeObj = scene.create_game_object("stanford");
+    //            cubeObj.get_component<components::Transform>().set_scale(glm::vec3(5));
+    //            cubeObj.get_component<components::Transform>().set_position(glm::vec3(-5, 2.0f, -10.0f));
+    //            cubeObj.get_component<components::Transform>().set_rotation_euler(glm::vec3(0, 210, 0));
+    //
+    //            auto& mesh = cubeObj.add_component<components::Mesh>("dragon.obj");
+    //
+    //            auto material = components::Material();
+    //            material.set_texture_slot_path(TextureType::Albedo, "oldiron/OldIron01_1K_BaseColor.png");
+    //            material.set_texture_slot_path(TextureType::Normal, "oldiron/OldIron01_1K_Normal.png");
+    //            material.set_texture_slot_path(TextureType::Metallic, "whiteTexture");
+    //            material.set_texture_slot_path(TextureType::Roughness, "whiteTexture");
+    //            material.set_texture_slot_path(TextureType::Occlusion, "whiteTexture");
+    //
+    //            cubeObj.add_component<components::Material>(material);
+    //        }
     //    {
     //        auto cubeObj = scene.create_game_object("ground");
     //        cubeObj.get_component<components::Transform>().set_position(glm::vec3(1.0f, 7.0f, 1.0f));

--- a/untie/src/untie.cpp
+++ b/untie/src/untie.cpp
@@ -28,38 +28,50 @@ Untie::Untie() {
         auto cubeObj = scene.create_game_object("cube_0");
         cubeObj.get_component<components::Transform>().set_position(glm::vec3(0, -10, 0));
         cubeObj.get_component<components::Transform>().set_scale(glm::vec3(15.0f, 1.0f, 15.0f));
+
         auto& mesh = cubeObj.add_component<components::Mesh>();
         mesh.create_cube();
-        auto& material = cubeObj.add_component<components::Material>();
-        material.set_texture_slot_path(TextureType::Albedo,"UV_Grid_test.png");
-        material.set_texture_slot_path(TextureType::Normal,"normal_tiles_1k.png");
-        material.set_texture_slot_path(TextureType::Metallic,"");
-        material.set_texture_slot_path(TextureType::Roughness,"");
-        material.set_texture_slot_path(TextureType::Occlusion,"");
+
+        auto material = components::Material();
+        material.set_texture_slot_path(TextureType::Albedo, "UV_Grid_test.png");
+        material.set_texture_slot_path(TextureType::Normal, "normal_tiles_1k.png");
+        material.set_texture_slot_path(TextureType::Metallic, "b");
+        material.set_texture_slot_path(TextureType::Roughness, "b2");
+        material.set_texture_slot_path(TextureType::Occlusion, "b3");
+
+        cubeObj.add_component<components::Material>(material);
     }
     {
         auto cubeObj = scene.create_game_object("cube_1");
         cubeObj.get_component<components::Transform>().set_position(glm::vec3(0.0f, 3.0f, 0.0f));
+
         auto& mesh = cubeObj.add_component<components::Mesh>();
         mesh.create_cube();
-        auto material = cubeObj.add_component<components::Material>();
-        material.set_texture_slot_path(TextureType::Albedo,"UV_Grid_test.png");
-        material.set_texture_slot_path(TextureType::Normal,"normal_tiles_1k.png");
-        material.set_texture_slot_path(TextureType::Metallic,"");
-        material.set_texture_slot_path(TextureType::Roughness,"");
-        material.set_texture_slot_path(TextureType::Occlusion,"");
+
+        auto material = components::Material();
+        material.set_texture_slot_path(TextureType::Albedo, "UV_Grid_test.png");
+        material.set_texture_slot_path(TextureType::Normal, "normal_tiles_1k.png");
+        material.set_texture_slot_path(TextureType::Metallic, "b");
+        material.set_texture_slot_path(TextureType::Roughness, "b2");
+        material.set_texture_slot_path(TextureType::Occlusion, "b3");
+
+        cubeObj.add_component<components::Material>(material);
     }
     {
         auto cubeObj = scene.create_game_object("ground");
         cubeObj.get_component<components::Transform>().set_position(glm::vec3(1.0f, 7.0f, 1.0f));
+
         auto& mesh = cubeObj.add_component<components::Mesh>();
         mesh.create_cube();
-        auto material = cubeObj.add_component<components::Material>();
-        material.set_texture_slot_path(TextureType::Albedo,"UV_Grid_test.png");
-        material.set_texture_slot_path(TextureType::Normal,"normal_tiles_1k.png");
-        material.set_texture_slot_path(TextureType::Metallic,"");
-        material.set_texture_slot_path(TextureType::Roughness,"");
-        material.set_texture_slot_path(TextureType::Occlusion,"");
+
+        auto material = components::Material();
+        material.set_texture_slot_path(TextureType::Albedo, "UV_Grid_test.png");
+        material.set_texture_slot_path(TextureType::Normal, "normal_tiles_1k.png");
+        material.set_texture_slot_path(TextureType::Metallic, "b");
+        material.set_texture_slot_path(TextureType::Roughness, "b2");
+        material.set_texture_slot_path(TextureType::Occlusion, "b3");
+
+        cubeObj.add_component<components::Material>(material);
     }
 }
 

--- a/untie/src/untie.cpp
+++ b/untie/src/untie.cpp
@@ -25,25 +25,42 @@ Untie::Untie() {
     }
 
     {
-        auto cubeObj = scene.create_game_object("cube_0");
-        cubeObj.get_component<components::Transform>().set_position(glm::vec3(0, -10, 0));
-        cubeObj.get_component<components::Transform>().set_scale(glm::vec3(15.0f, 1.0f, 15.0f));
+//        auto cubeObj = scene.create_game_object("cube_0");
+//        cubeObj.get_component<components::Transform>().set_position(glm::vec3(0, -10, 0));
+//        cubeObj.get_component<components::Transform>().set_scale(glm::vec3(15.0f, 1.0f, 15.0f));
+//
+//        auto& mesh = cubeObj.add_component<components::Mesh>();
+//        mesh.create_cube();
+//
+//        auto material = components::Material();
+//        material.set_texture_slot_path(TextureType::Albedo, "UV_Grid_test.png");
+//        material.set_texture_slot_path(TextureType::Normal, "normal_tiles_1k.png");
+//        material.set_texture_slot_path(TextureType::Metallic, "whiteTexture");
+//        material.set_texture_slot_path(TextureType::Roughness, "whiteTexture");
+//        material.set_texture_slot_path(TextureType::Occlusion, "whiteTexture");
+//
+//        cubeObj.add_component<components::Material>(material);
+    }
+    {
+        auto cubeObj = scene.create_game_object("sphere_1");
+        cubeObj.get_component<components::Transform>().set_position(glm::vec3(0.0f, 4.0f, 0.0f));
 
         auto& mesh = cubeObj.add_component<components::Mesh>();
-        mesh.create_cube();
+        mesh.load_mesh("cube.obj");
 
         auto material = components::Material();
-        material.set_texture_slot_path(TextureType::Albedo, "UV_Grid_test.png");
+        material.set_texture_slot_path(TextureType::Albedo, "whiteTexture");
         material.set_texture_slot_path(TextureType::Normal, "normal_tiles_1k.png");
         material.set_texture_slot_path(TextureType::Metallic, "whiteTexture");
         material.set_texture_slot_path(TextureType::Roughness, "whiteTexture");
         material.set_texture_slot_path(TextureType::Occlusion, "whiteTexture");
 
         cubeObj.add_component<components::Material>(material);
+
     }
     {
         auto cubeObj = scene.create_game_object("cube_1");
-        cubeObj.get_component<components::Transform>().set_position(glm::vec3(0.0f, 3.0f, 0.0f));
+        cubeObj.get_component<components::Transform>().set_position(glm::vec3(0.0f, 1.0f, 0.0f));
 
         auto& mesh = cubeObj.add_component<components::Mesh>();
         mesh.create_cube();
@@ -57,22 +74,22 @@ Untie::Untie() {
 
         cubeObj.add_component<components::Material>(material);
     }
-    {
-        auto cubeObj = scene.create_game_object("ground");
-        cubeObj.get_component<components::Transform>().set_position(glm::vec3(1.0f, 7.0f, 1.0f));
-
-        auto& mesh = cubeObj.add_component<components::Mesh>();
-        mesh.create_cube();
-
-        auto material = components::Material();
-        material.set_texture_slot_path(TextureType::Albedo, "UV_Grid_test.png");
-        material.set_texture_slot_path(TextureType::Normal, "normal_tiles_1k.png");
-        material.set_texture_slot_path(TextureType::Metallic, "whiteTexture");
-        material.set_texture_slot_path(TextureType::Roughness, "whiteTexture");
-        material.set_texture_slot_path(TextureType::Occlusion, "whiteTexture");
-
-        cubeObj.add_component<components::Material>(material);
-    }
+//    {
+//        auto cubeObj = scene.create_game_object("ground");
+//        cubeObj.get_component<components::Transform>().set_position(glm::vec3(1.0f, 7.0f, 1.0f));
+//
+//        auto& mesh = cubeObj.add_component<components::Mesh>();
+//        mesh.create_cube();
+//
+//        auto material = components::Material();
+//        material.set_texture_slot_path(TextureType::Albedo, "UV_Grid_test.png");
+//        material.set_texture_slot_path(TextureType::Normal, "normal_tiles_1k.png");
+//        material.set_texture_slot_path(TextureType::Metallic, "whiteTexture");
+//        material.set_texture_slot_path(TextureType::Roughness, "whiteTexture");
+//        material.set_texture_slot_path(TextureType::Occlusion, "whiteTexture");
+//
+//        cubeObj.add_component<components::Material>(material);
+//    }
 }
 
 void Untie::run() {

--- a/untie/src/untie.cpp
+++ b/untie/src/untie.cpp
@@ -42,8 +42,8 @@ Untie::Untie() {
         //        cubeObj.add_component<components::Material>(material);
     } {
         auto cubeObj = scene.create_game_object("loaded_cube");
-        cubeObj.get_component<components::Transform>().set_position(glm::vec3(0.0f, -5.0f, 0.0f));
-        cubeObj.get_component<components::Transform>().set_scale(glm::vec3(10.0f));
+        cubeObj.get_component<components::Transform>().set_position(glm::vec3(-5.0f, 0.0f, -10.0f));
+        cubeObj.get_component<components::Transform>().set_scale(glm::vec3(15, 1, 15));
         cubeObj.get_component<components::Transform>().set_rotation_euler(glm::vec3(0, 45, 0));
 
         auto& mesh = cubeObj.add_component<components::Mesh>();
@@ -59,15 +59,17 @@ Untie::Untie() {
         cubeObj.add_component<components::Material>(material);
     }
     {
-        auto cubeObj = scene.create_game_object("cube_1");
-        cubeObj.get_component<components::Transform>().set_position(glm::vec3(-4.0f, 6.0f, -4.0f));
+        auto cubeObj = scene.create_game_object("stanford");
+        cubeObj.get_component<components::Transform>().set_scale(glm::vec3(5));
+        cubeObj.get_component<components::Transform>().set_position(glm::vec3(-5, 2.0f, -10.0f));
+        cubeObj.get_component<components::Transform>().set_rotation_euler(glm::vec3(0, 210, 0));
 
         auto& mesh = cubeObj.add_component<components::Mesh>();
-        mesh.create_cube();
+        mesh.load_mesh("dragon.obj");
 
         auto material = components::Material();
-        material.set_texture_slot_path(TextureType::Albedo, "UV_Grid_test.png");
-        material.set_texture_slot_path(TextureType::Normal, "normal_tiles_1k.png");
+        material.set_texture_slot_path(TextureType::Albedo, "oldiron/OldIron01_1K_BaseColor.png");
+        material.set_texture_slot_path(TextureType::Normal, "oldiron/OldIron01_1K_Normal.png");
         material.set_texture_slot_path(TextureType::Metallic, "whiteTexture");
         material.set_texture_slot_path(TextureType::Roughness, "whiteTexture");
         material.set_texture_slot_path(TextureType::Occlusion, "whiteTexture");


### PR DESCRIPTION
- AssetManager class
- - Image files loaded via stbi & cached 
- - Image fallback 
- - Image white texture 
- - Mesh .obj files loaded custom loader (triangulated .objs files ONLY) (modified from beardyking ProcGL)
- - mesh fallback (bug : mesh generated has incorrect Index buffer / UV due to uint16 being replaced with float / uint32)
- - index buffer change made due to large obj files would run out of index count 

- Asset class
- - is base class for Mesh / Texture / SharedProgram
- - ShaderProgram not impl with AssetManager (binary path retriever must be written first)
- - contains asset state / type enum defined in <knoting/types.h>
- - State : Idle, Loading, Finished, Failed, LAST 
- - Type : Unknown, Texture, Mesh, Shader, Cubemap, LAST (cubemap not used yet)
- - type set when derived class is created
- - state set on_awake or when fallback is generated

- AssetManager class
- - Manages All assets 
- - Loads assets via static class and returns weak_ptr<T>
- - All shared_ptr<Assets> loaded stored in vector
- - manual loading of assets currently being done
- - should look at all files inside of '/res' and load them based on some file
- - Materials should be eventually be an Asset and should loaded from file when serialization is impl 

- InstancedMesh class 
- - pass path in and on_awake calls LoadAsset(path) to gets existing asset if does not exist creates new from path if fail gets fallback from manager 
- - InstancedMesh class instead of passing mesh for if extended functionality is needed later down the line
- - also in ECS shared_ptr<components::Mesh> is not clean

- Material class 
- - Image paths & slot number passed in and assets loaded internally if 
- - when serialization & binary path binary path is retriever is impl shader paths should passed in or use fallback 

- SpotLight class
- - class containing spotlight information 

- LightData class
- - Container for information from Light Systems
- - push packed data to various light types
- - bind uninformed for various light types 
- - SpotlightData nested class
- - - Container for spotlight data 
- - - position, inner radius, outer radius, color, " direction data" not impl yet
- - Other containers to be written when BRDF is impl

- New Assets
- - Mesh 
- - - uv_cube.obj 
- - - light.obj 
- - - dragon.obj (Stanford dragon 83k)
- - Images
- - - oldiron / OldIron01_1K_BaseColor.png
- - - oldiron / OldIron01_1K_Height.png
- - - oldiron / OldIron01_1K_Metallic.png
- - - oldiron / OldIron01_1K_Normal.png
- - - oldiron / OldIron01_1K_Roughness.png
- - - From : https://www.cgbookcase.com/textures/old-iron-01/