### PR TITLE
feat: add executable path retriever

### DIFF
--- a/core/inc/knoting/asset.h
+++ b/core/inc/knoting/asset.h
@@ -3,14 +3,14 @@
 #include <knoting/types.h>
 #include <string>
 
-static constexpr char PATH_TEXTURE[] = "../res/textures/";
-static constexpr char PATH_MODELS[] = "../res/misc/";
-static constexpr char PATH_SHADER[] = "../res/shaders/";
+static constexpr std::string_view PATH_TEXTURE = "textures/";
+static constexpr std::string_view PATH_MODELS = "misc/";
+static constexpr std::string_view PATH_SHADER = "shaders/";
 
-static constexpr char fallbackTextureName[] = "fallbackTexture";
-static constexpr char fallbackMeshName[] = "fallbackMesh";
-static constexpr char fallbackShaderName[] = "fallbackShader";
-static constexpr char fallbackCubeMapName[] = "fallbackCubeMap";
+static constexpr std::string_view fallbackTextureName = "fallbackTexture";
+static constexpr std::string_view fallbackMeshName = "fallbackMesh";
+static constexpr std::string_view fallbackShaderName = "fallbackShader";
+static constexpr std::string_view fallbackCubeMapName = "fallbackCubeMap";
 
 namespace knot {
 using namespace asset;

--- a/core/inc/knoting/asset_manager.h
+++ b/core/inc/knoting/asset_manager.h
@@ -25,6 +25,8 @@ class AssetManager : public Subsystem {
     void load_assets_manual();
     void load_assets_serialize();
 
+    static std::filesystem::path get_resources_path();
+
     static std::optional<std::reference_wrapper<AssetManager>> get_asset_manager() { return s_assetManager; };
 
     template <typename T>
@@ -37,9 +39,11 @@ class AssetManager : public Subsystem {
 
    private:
     std::map<std::string, std::shared_ptr<Asset>> m_assets;
+
+    static std::filesystem::path get_executable_path();
+
     inline static std::optional<std::reference_wrapper<AssetManager>> s_assetManager = std::nullopt;
 
-   private:
     template <typename T>
     inline std::weak_ptr<T> internal_load_asset(const std::string& path) {
         static_assert(!std::is_base_of<T, Asset>::value, "ASSET IS NOT OF BASE CLASS ASSET");

--- a/core/inc/knoting/types.h
+++ b/core/inc/knoting/types.h
@@ -22,13 +22,13 @@ enum class TextureType { Albedo, Normal, Metallic, Roughness, Occlusion, LAST };
 using namespace glm;
 using namespace uuids;
 
-using vec2i = vec<2, i32>;
-using vec2u = vec<2, u32>;
-using vec2d = vec<2, f64>;
-using vec3i = vec<3, i32>;
-using vec3d = vec<3, f64>;
-using vec4i = vec<4, i32>;
-using vec4d = vec<4, f64>;
+using vec2i = vec<2, int>;
+using vec2u = vec<2, uint>;
+using vec2d = vec<2, double>;
+using vec3i = vec<3, int>;
+using vec3d = vec<3, double>;
+using vec4i = vec<4, int>;
+using vec4d = vec<4, double>;
 
 }  // namespace knot
 

--- a/core/src/asset_manager.cpp
+++ b/core/src/asset_manager.cpp
@@ -50,7 +50,7 @@ void AssetManager::load_assets_serialize() {}
 
 std::filesystem::path AssetManager::get_resources_path() {
     std::filesystem::path path = get_executable_path();
-    return path.parent_path().parent_path().append("res");
+    return path.parent_path().parent_path().append("res/");
 }
 
 std::filesystem::path AssetManager::get_executable_path() {

--- a/core/src/asset_manager.cpp
+++ b/core/src/asset_manager.cpp
@@ -1,5 +1,12 @@
 #include <knoting/asset_manager.h>
 
+#if defined(WIN32) || defined(_WIN32)
+#include <windows.h>
+#elif defined(__linux__)
+#include <sys/types.h>
+#include <unistd.h>
+#endif
+
 namespace knot {
 
 void AssetManager::on_awake() {
@@ -40,4 +47,26 @@ void AssetManager::load_assets_manual() {
 }
 
 void AssetManager::load_assets_serialize() {}
+
+std::filesystem::path AssetManager::get_resources_path() {
+    std::filesystem::path path = get_executable_path();
+    return path.parent_path().parent_path().append("res");
+}
+
+std::filesystem::path AssetManager::get_executable_path() {
+    std::array<char, 512> buffer;
+    std::fill(buffer.begin(), buffer.end(), '\0');
+
+#if defined(WIN32) || defined(_WIN32)
+    GetModuleFileName(nullptr, buffer.data(), MAX_PATH);
+#elif defined(__linux__)
+    ssize_t count = readlink("/proc/self/exe", buffer.data(), buffer.size());
+#endif
+
+    std::string result = std::string(buffer.begin(), buffer.end());
+    std::replace(result.begin(), result.end(), '\\', '/');
+
+    return result;
+}
+
 }  // namespace knot

--- a/core/src/shader_program.cpp
+++ b/core/src/shader_program.cpp
@@ -69,33 +69,34 @@ bool ShaderProgram::does_file_path_exist(const std::string& path) {
 }
 
 std::string ShaderProgram::get_cross_platform_path(const std::string& folderName, const std::string& fileName) {
-    std::filesystem::path shaderPath = "SHADER_BINARY_NOT_SET";
+    std::filesystem::path shaderPath = AssetManager::get_resources_path();
     switch (bgfx::getRendererType()) {
         case bgfx::RendererType::Noop:
         case bgfx::RendererType::Direct3D9:
-            shaderPath = AssetManager::get_resources_path().append(PATH_SHADER).append(folderName).append("dx9/");
+            shaderPath = shaderPath.append(PATH_SHADER).append(folderName).append("dx9/");
             break;
         case bgfx::RendererType::Direct3D11:
         case bgfx::RendererType::Direct3D12:
-            shaderPath = AssetManager::get_resources_path().append(PATH_SHADER).append(folderName).append("dx11/");
+            shaderPath = shaderPath.append(PATH_SHADER).append(folderName).append("dx11/");
             break;
         case bgfx::RendererType::Gnm:
             // TODO
             // break;
         case bgfx::RendererType::Metal:
-            shaderPath = AssetManager::get_resources_path().append(PATH_SHADER).append(folderName).append("metal/");
+            shaderPath = shaderPath.append(PATH_SHADER).append(folderName).append("metal/");
             break;
         case bgfx::RendererType::OpenGL:
-            shaderPath = AssetManager::get_resources_path().append(PATH_SHADER).append(folderName).append("glsl/");
+            shaderPath = shaderPath.append(PATH_SHADER).append(folderName).append("glsl/");
             break;
         case bgfx::RendererType::OpenGLES:
-            shaderPath = AssetManager::get_resources_path().append(PATH_SHADER).append(folderName).append("essl/");
+            shaderPath = shaderPath.append(PATH_SHADER).append(folderName).append("essl/");
             break;
         case bgfx::RendererType::Vulkan:
-            shaderPath = AssetManager::get_resources_path().append(PATH_SHADER).append(folderName).append("spirv/");
+            shaderPath = shaderPath.append(PATH_SHADER).append(folderName).append("spirv/");
             break;
         default:
-            shaderPath = "SHADER_BINARY_NOT_SET";
+            log::error("Render type not supported to retrieve shader path");
+            shaderPath = shaderPath.append(PATH_SHADER).append(folderName).append("unkown/");
             break;
     }
 

--- a/core/src/shader_program.cpp
+++ b/core/src/shader_program.cpp
@@ -101,7 +101,7 @@ std::string ShaderProgram::get_cross_platform_path(const std::string& folderName
     }
 
     shaderPath.append(fileName);
-    return shaderPath;
+    return shaderPath.string();
 }
 void ShaderProgram::generate_default_asset() {}
 

--- a/core/src/shader_program.cpp
+++ b/core/src/shader_program.cpp
@@ -1,5 +1,6 @@
 #include <knoting/shader_program.h>
 
+#include <knoting/asset_manager.h>
 #include <knoting/log.h>
 #include <filesystem>
 #include <fstream>
@@ -68,31 +69,33 @@ bool ShaderProgram::does_file_path_exist(const std::string& path) {
 }
 
 std::string ShaderProgram::get_cross_platform_path(const std::string& folderName, const std::string& fileName) {
-    std::string shaderPath = "SHADER_BINARY_NOT_SET";
+    std::filesystem::path shaderPath = "SHADER_BINARY_NOT_SET";
     switch (bgfx::getRendererType()) {
         case bgfx::RendererType::Noop:
         case bgfx::RendererType::Direct3D9:
-            shaderPath = "../res/shaders/" + folderName + "/dx9/";
+            shaderPath = AssetManager::get_resources_path().append(PATH_SHADER).append(folderName).append("dx9/");
             break;
         case bgfx::RendererType::Direct3D11:
         case bgfx::RendererType::Direct3D12:
-            shaderPath = "../res/shaders/" + folderName + "/dx11/";
+            shaderPath = AssetManager::get_resources_path().append(PATH_SHADER).append(folderName).append("dx11/");
             break;
         case bgfx::RendererType::Gnm:
-            break;
+            // TODO
+            // break;
         case bgfx::RendererType::Metal:
-            shaderPath = "../res/shaders/" + folderName + "/metal/";
+            shaderPath = AssetManager::get_resources_path().append(PATH_SHADER).append(folderName).append("metal/");
             break;
         case bgfx::RendererType::OpenGL:
-            shaderPath = "../res/shaders/" + folderName + "/glsl/";
+            shaderPath = AssetManager::get_resources_path().append(PATH_SHADER).append(folderName).append("glsl/");
             break;
         case bgfx::RendererType::OpenGLES:
-            shaderPath = "../res/shaders/" + folderName + "/essl/";
+            shaderPath = AssetManager::get_resources_path().append(PATH_SHADER).append(folderName).append("essl/");
             break;
         case bgfx::RendererType::Vulkan:
-            shaderPath = "../res/shaders/" + folderName + "/spirv/";
+            shaderPath = AssetManager::get_resources_path().append(PATH_SHADER).append(folderName).append("spirv/");
             break;
-        case bgfx::RendererType::Count:
+        default:
+            shaderPath = "SHADER_BINARY_NOT_SET";
             break;
     }
 

--- a/core/src/texture.cpp
+++ b/core/src/texture.cpp
@@ -1,3 +1,4 @@
+#include <knoting/asset_manager.h>
 #include <knoting/log.h>
 #include <knoting/texture.h>
 #include <stb_image.h>
@@ -24,11 +25,10 @@ void Texture::on_destroy() {
 
 // TODO Return fail state for the template so that it can set the idX to the default fallback texture
 void Texture::load_texture_2d(const std::string& path, bool usingMipMaps, bool usingAnisotropicFiltering) {
-    std::string fullPath = PATH_TEXTURE + path;
-    std::filesystem::path fs_path = fullPath;
+    std::filesystem::path fsPath = AssetManager::get_resources_path().append(PATH_TEXTURE).append(path);
 
-    if (!exists(fs_path)) {
-        log::error(fullPath + " - does not Exist");
+    if (!exists(fsPath)) {
+        log::error("{} - does not Exist", fsPath.string());
         m_textureHandle = BGFX_INVALID_HANDLE;
     }
 
@@ -36,11 +36,11 @@ void Texture::load_texture_2d(const std::string& path, bool usingMipMaps, bool u
     glm::ivec2 img_size;
     int channels;
     stbi_set_flip_vertically_on_load(true);
-    stbi_uc* data = stbi_load(fullPath.c_str(), &img_size.x, &img_size.y, &channels, 0);
+    stbi_uc* data = stbi_load(fsPath.string().c_str(), &img_size.x, &img_size.y, &channels, 0);
     int numberOfLayers = 1;
 
     if (!data) {
-        log::error("Failed to load image: " + fullPath);
+        log::error("Failed to load image: {}", fsPath.string());
         m_assetState = AssetState::Failed;
         return;
     }

--- a/core/src/window.cpp
+++ b/core/src/window.cpp
@@ -39,6 +39,7 @@ Window::Window(int width, int height, std::string title, Engine& engine)
     // To avoid creating a render thread we need to call renderFrame() manually
     bgfx::renderFrame();
     bgfx::Init init;
+
 #if BX_PLATFORM_WINDOWS
     init.platformData.nwh = glfwGetWin32Window(m_window);
 #elif BX_PLATFORM_LINUX || BX_PLATFORM_BSD


### PR DESCRIPTION
Change how me manage relative paths. Now it retrieves where the executable is located, and using C++'s filesystem, it adds any other path needed.
This allows us to execute the binary from paths other than the `dist/bin` directory.