### PR TITLE
feat: add third-party middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ debug/
 compile_commands.json
 Font Awesome*
 scene.json
+lib/
 
 # */**/renderer.cc
 # */**/renderer.h

--- a/.gitmodules
+++ b/.gitmodules
@@ -40,3 +40,6 @@
 [submodule "third/cereal"]
 	path = third/cereal
 	url = https://github.com/USCiLab/cereal.git
+[submodule "third/yojimbo"]
+	path = third/yojimbo
+	url = https://github.com/networkprotocol/yojimbo.git

--- a/cmake/FindFMod.cmake
+++ b/cmake/FindFMod.cmake
@@ -1,0 +1,103 @@
+# FMod_INCLUDE_DIR -- include
+# FMod_LIBRARY     -- libs
+
+find_path(FMod_INCLUDE_DIR
+    NAMES
+        "fmod.h"
+    HINTS
+        ${CMAKE_SOURCE_DIR}/lib/include
+        ${FMod_HOME}/include
+        $ENV{FMod_HOME}/include
+    PATHS
+        "$ENV{PROGRAMFILES}"
+        ~/Library/Frameworks
+        /Library/Frameworks
+        /usr/local
+        /usr
+        /sw # Fink
+        /opt/local # DarwinPorts
+        /opt/csw # Blastwave
+        /opt
+    DOC
+        "FMod - Headers"
+)
+
+if (WIN32)
+    find_library(FMod_LIBRARY
+        NAMES
+            fmod_vc
+        HINTS
+            ${CMAKE_SOURCE_DIR}/lib/x86_64/windows
+            ${FMod_HOME}
+            $ENV{FMod_HOME}
+        PATHS
+            ~/Library/Frameworks
+            /Library/Frameworks
+            /usr/local
+            /usr
+            /sw
+            /opt/local
+            /opt/csw
+            /opt
+        PATH_SUFFIXES
+            lib
+        DOC
+            "FMod - Library"
+    )
+
+    find_package_handle_standard_args(FMod REQUIRED_VARS FMod_INCLUDE_DIR FMod_LIBRARY)
+
+    mark_as_advanced(FMod_LIBRARY FMod_INCLUDE_DIR FMod_SHARED_LIBRARY)
+else()
+    find_library(FMod_SHARED_LIBRARY
+        NAMES
+            fmod
+        HINTS
+            ${CMAKE_SOURCE_DIR}/lib/x86_64/linux
+            ${FMod_HOME}
+            $ENV{FMod_HOME}
+        PATHS
+            ~/Library/Frameworks
+            /Library/Frameworks
+            /usr/local
+            /usr
+            /sw
+            /opt/local
+            /opt/csw
+            /opt
+        PATH_SUFFIXES
+            so
+        DOC
+            "FMod - Shared Library"
+    )
+
+    find_package_handle_standard_args(FMod REQUIRED_VARS FMod_INCLUDE_DIR)
+
+    mark_as_advanced(FMod_INCLUDE_DIR FMod_SHARED_LIBRARY)
+endif()
+
+add_library(FMod SHARED IMPORTED)
+
+set_target_properties(FMod
+    PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES
+            "${FMod_INCLUDE_DIR}"
+         IMPORTED_LINK_INTERFACE_LANGUAGES
+             "C++"
+)
+
+if(WIN32)
+    set_target_properties(FMod
+        PROPERTIES
+            IMPORTED_IMPLIB
+                "${FMod_LIBRARY}"
+            IMPORTED_LOCATION
+                "${FMod_SHARED_LIBRARY}"
+    )
+else()
+    set_target_properties(FMod
+        PROPERTIES
+            IMPORTED_LOCATION
+                "${FMod_SHARED_LIBRARY}"
+    )
+endif()

--- a/cmake/FindMbedTLS.cmake
+++ b/cmake/FindMbedTLS.cmake
@@ -1,0 +1,187 @@
+# Copyright 2021 AVSystem <avsystem@avsystem.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#.rst:
+# FindMbedTLS
+# -----------
+#
+# Find the mbedTLS encryption library.
+#
+# Imported Targets
+# ^^^^^^^^^^^^^^^^
+#
+# This module defines the following :prop_tgt:`IMPORTED` targets:
+#
+# ``mbedtls``
+#   The mbedTLS ``mbedtls`` library, if found.
+# ``mbedcrypto``
+#   The mbedtls ``crypto`` library, if found.
+# ``mbedx509``
+#   The mbedtls ``x509`` library, if found.
+#
+# Result Variables
+# ^^^^^^^^^^^^^^^^
+#
+# This module will set the following variables in your project:
+#
+# ``MBEDTLS_FOUND``
+#   System has the mbedTLS library.
+# ``MBEDTLS_INCLUDE_DIR``
+#   The mbedTLS include directory.
+# ``MBEDTLS_LIBRARY``
+#   The mbedTLS SSL library.
+# ``MBEDTLS_CRYPTO_LIBRARY``
+#   The mbedTLS crypto library.
+# ``MBEDTLS_X509_LIBRARY``
+#   The mbedTLS x509 library.
+# ``MBEDTLS_LIBRARIES``
+#   All mbedTLS libraries.
+# ``MBEDTLS_VERSION``
+#   This is set to ``$major.$minor.$patch``.
+# ``MBEDTLS_VERSION_MAJOR``
+#   Set to major mbedTLS version number.
+# ``MBEDTLS_VERSION_MINOR``
+#   Set to minor mbedTLS version number.
+# ``MBEDTLS_VERSION_PATCH``
+#   Set to patch mbedTLS version number.
+#
+# Hints
+# ^^^^^
+#
+# Set ``MBEDTLS_ROOT_DIR`` to the root directory of an mbedTLS installation.
+# Set ``MBEDTLS_USE_STATIC_LIBS`` to ``TRUE`` to look for static libraries.
+
+if(MBEDTLS_ROOT_DIR)
+    # Disable re-rooting paths in find_path/find_library.
+    # This assumes MBEDTLS_ROOT_DIR is an absolute path.
+    set(_EXTRA_FIND_ARGS "NO_DEFAULT_PATH")
+endif()
+
+find_path(MBEDTLS_INCLUDE_DIR
+          NAMES mbedtls/ssl.h
+          HINTS
+            ${CMAKE_SOURCE_DIR}/lib/include
+            ${MBEDTLS_ROOT_DIR}
+          ${_EXTRA_FIND_ARGS})
+
+# based on https://github.com/ARMmbed/mbedtls/issues/298
+set(MBEDTLS_BUILD_INFO_FILE)
+if(MBEDTLS_INCLUDE_DIR)
+    if(EXISTS "${MBEDTLS_INCLUDE_DIR}/mbedtls/build_info.h")
+        # Mbed TLS 3.x
+        set(MBEDTLS_BUILD_INFO_FILE "${MBEDTLS_INCLUDE_DIR}/mbedtls/build_info.h")
+    elseif(EXISTS "${MBEDTLS_INCLUDE_DIR}/mbedtls/version.h")
+        # Mbed TLS 2.x
+        set(MBEDTLS_BUILD_INFO_FILE "${MBEDTLS_INCLUDE_DIR}/mbedtls/version.h")
+    endif()
+endif()
+
+if(MBEDTLS_BUILD_INFO_FILE)
+    file(STRINGS "${MBEDTLS_BUILD_INFO_FILE}" VERSION_STRING_LINE REGEX "^#define MBEDTLS_VERSION_STRING[ \\t\\n\\r]+\"[^\"]*\"$")
+    file(STRINGS "${MBEDTLS_BUILD_INFO_FILE}" VERSION_MAJOR_LINE REGEX "^#define MBEDTLS_VERSION_MAJOR[ \\t\\n\\r]+[0-9]+$")
+    file(STRINGS "${MBEDTLS_BUILD_INFO_FILE}" VERSION_MINOR_LINE REGEX "^#define MBEDTLS_VERSION_MINOR[ \\t\\n\\r]+[0-9]+$")
+    file(STRINGS "${MBEDTLS_BUILD_INFO_FILE}" VERSION_PATCH_LINE REGEX "^#define MBEDTLS_VERSION_PATCH[ \\t\\n\\r]+[0-9]+$")
+
+    string(REGEX REPLACE "^#define MBEDTLS_VERSION_STRING[ \\t\\n\\r]+\"([^\"]*)\"$" "\\1" MBEDTLS_VERSION "${VERSION_STRING_LINE}")
+    string(REGEX REPLACE "^#define MBEDTLS_VERSION_MAJOR[ \\t\\n\\r]+([0-9]+)$" "\\1" MBEDTLS_VERSION_MAJOR "${VERSION_MAJOR_LINE}")
+    string(REGEX REPLACE "^#define MBEDTLS_VERSION_MINOR[ \\t\\n\\r]+([0-9]+)$" "\\1" MBEDTLS_VERSION_MINOR "${VERSION_MINOR_LINE}")
+    string(REGEX REPLACE "^#define MBEDTLS_VERSION_PATCH[ \\t\\n\\r]+([0-9]+)$" "\\1" MBEDTLS_VERSION_PATCH "${VERSION_PATCH_LINE}")
+endif()
+
+
+# if(MBEDTLS_USE_STATIC_LIBS)
+#     set(_MBEDTLS_LIB_NAME libmbedtls.a)
+#     set(_MBEDTLS_CRYPTO_LIB_NAME libmbedcrypto.a)
+#     set(_MBEDTLS_X509_LIB_NAME libmbedx509.a)
+# else()
+    set(_MBEDTLS_LIB_NAME mbedtls)
+    set(_MBEDTLS_CRYPTO_LIB_NAME mbedcrypto)
+    set(_MBEDTLS_X509_LIB_NAME mbedx509)
+# endif()
+
+if (WIN32)
+    set(LIB_LOCAL_PATH "${CMAKE_SOURCE_DIR}/lib/x86_64/windows")
+else()
+    set(LIB_LOCAL_PATH "${CMAKE_SOURCE_DIR}/lib/x86_64/linux")
+endif()
+
+find_library(MBEDTLS_LIBRARY
+             NAMES ${_MBEDTLS_LIB_NAME}
+             PATH_SUFFIXES lib
+             HINTS
+                ${LIB_LOCAL_PATH}
+                ${MBEDTLS_ROOT_DIR}
+             ${_EXTRA_FIND_ARGS})
+
+find_library(MBEDTLS_CRYPTO_LIBRARY
+             NAMES ${_MBEDTLS_CRYPTO_LIB_NAME}
+             PATH_SUFFIXES lib
+             HINTS
+                ${LIB_LOCAL_PATH}
+                ${MBEDTLS_ROOT_DIR}
+             ${_EXTRA_FIND_ARGS})
+
+find_library(MBEDTLS_X509_LIBRARY
+             NAMES ${_MBEDTLS_X509_LIB_NAME}
+             PATH_SUFFIXES lib
+             HINTS
+                ${LIB_LOCAL_PATH}
+                ${MBEDTLS_ROOT_DIR}
+             ${_EXTRA_FIND_ARGS})
+
+set(MBEDTLS_LIBRARIES ${MBEDTLS_LIBRARY} ${MBEDTLS_CRYPTO_LIBRARY} ${MBEDTLS_X509_LIBRARY})
+
+if(MBEDTLS_INCLUDE_DIR)
+    set(MBEDTLS_FOUND TRUE)
+endif()
+
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(mbedTLS
+                                  FOUND_VAR MBEDTLS_FOUND
+                                  REQUIRED_VARS
+                                      MBEDTLS_INCLUDE_DIR
+                                      MBEDTLS_LIBRARY
+                                      MBEDTLS_CRYPTO_LIBRARY
+                                      MBEDTLS_X509_LIBRARY
+                                      MBEDTLS_LIBRARIES
+                                      MBEDTLS_VERSION
+                                  VERSION_VAR MBEDTLS_VERSION)
+
+
+if(NOT TARGET mbedcrypto)
+    add_library(mbedcrypto UNKNOWN IMPORTED)
+    set_target_properties(mbedcrypto PROPERTIES
+                          INTERFACE_INCLUDE_DIRECTORIES "${MBEDTLS_INCLUDE_DIR}"
+                          IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+                          IMPORTED_LOCATION "${MBEDTLS_CRYPTO_LIBRARY}")
+endif()
+
+if(NOT TARGET mbedx509)
+    add_library(mbedx509 UNKNOWN IMPORTED)
+    set_target_properties(mbedx509 PROPERTIES
+                          INTERFACE_INCLUDE_DIRECTORIES "${MBEDTLS_INCLUDE_DIR}"
+                          INTERFACE_LINK_LIBRARIES mbedcrypto
+                          IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+                          IMPORTED_LOCATION "${MBEDTLS_X509_LIBRARY}")
+endif()
+
+if(NOT TARGET mbedtls)
+    add_library(mbedtls UNKNOWN IMPORTED)
+    set_target_properties(mbedtls PROPERTIES
+                          INTERFACE_INCLUDE_DIRECTORIES "${MBEDTLS_INCLUDE_DIR}"
+                          INTERFACE_LINK_LIBRARIES mbedx509
+                          IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+                          IMPORTED_LOCATION "${MBEDTLS_LIBRARY}")
+endif()

--- a/cmake/FindNoesisGUI.cmake
+++ b/cmake/FindNoesisGUI.cmake
@@ -1,0 +1,105 @@
+# NoesisGUI_INCLUDE_DIR -- include
+# NoesisGUI_LIBRARY     -- libs
+
+find_path(NoesisGUI_INCLUDE_DIR
+    NAMES
+        "NoesisPCH.h"
+    HINTS
+        ${CMAKE_SOURCE_DIR}/lib/include
+        ${NOESIS_HOME}/include
+        $ENV{NOESIS_HOME}/include
+    PATHS
+        "$ENV{PROGRAMFILES}"
+        ~/Library/Frameworks
+        /Library/Frameworks
+        /usr/local
+        /usr
+        /sw # Fink
+        /opt/local # DarwinPorts
+        /opt/csw # Blastwave
+        /opt
+    DOC
+        "Noesis - Headers"
+)
+
+if (WIN32)
+    find_library(NoesisGUI_LIBRARY
+        NAMES
+            Noesis
+        HINTS
+            ${CMAKE_SOURCE_DIR}/lib/x86_64/windows
+            ${NOESIS_HOME}
+            $ENV{NOESIS_HOME}
+        PATHS
+            ~/Library/Frameworks
+            /Library/Frameworks
+            /usr/local
+            /usr
+            /sw
+            /opt/local
+            /opt/csw
+            /opt
+        PATH_SUFFIXES
+            lib
+        DOC
+            "Noesis - Library"
+    )
+
+    find_package_handle_standard_args(NoesisGUI REQUIRED_VARS NoesisGUI_INCLUDE_DIR NoesisGUI_LIBRARY)
+
+    mark_as_advanced(NoesisGUI_LIBRARY NoesisGUI_INCLUDE_DIR NoesisGUI_SHARED_LIBRARY)
+else()
+    find_library(NoesisGUI_SHARED_LIBRARY
+        NAMES
+            Noesis
+        HINTS
+            ${CMAKE_SOURCE_DIR}/lib/x86_64/linux
+            ${NOESIS_HOME}
+            $ENV{NOESIS_HOME}
+        PATHS
+            ~/Library/Frameworks
+            /Library/Frameworks
+            /usr/local
+            /usr
+            /sw
+            /opt/local
+            /opt/csw
+            /opt
+        PATH_SUFFIXES
+            so
+        DOC
+            "Noesis - Shared Library"
+    )
+
+    find_package_handle_standard_args(NoesisGUI REQUIRED_VARS NoesisGUI_INCLUDE_DIR)
+
+    mark_as_advanced(NoesisGUI_INCLUDE_DIR NoesisGUI_SHARED_LIBRARY)
+endif()
+
+add_library(NoesisGUI SHARED IMPORTED)
+
+set_target_properties(NoesisGUI
+    PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES
+            "${NoesisGUI_INCLUDE_DIR}"
+         IMPORTED_LINK_INTERFACE_LANGUAGES
+             "C++"
+)
+
+if(WIN32)
+    set_target_properties(NoesisGUI
+        PROPERTIES
+            IMPORTED_IMPLIB
+                "${NoesisGUI_LIBRARY}"
+            IMPORTED_LOCATION
+                "${NoesisGUI_SHARED_LIBRARY}"
+    )
+else()
+    set_target_properties(NoesisGUI
+        PROPERTIES
+            IMPORTED_CONFIGURATIONS
+                "Debug"
+            IMPORTED_LOCATION
+                "${NoesisGUI_SHARED_LIBRARY}"
+    )
+endif()

--- a/cmake/Findsodium.cmake
+++ b/cmake/Findsodium.cmake
@@ -1,0 +1,303 @@
+# Written in 2016 by Henrik Steffen Gaßmann <henrik@gassmann.onl>
+#
+# To the extent possible under law, the author(s) have dedicated all copyright
+# and related and neighboring rights to this software to the public domain
+# worldwide. This software is distributed without any warranty.
+#
+# You should have received a copy of the CC0 Public Domain Dedication along with
+# this software. If not, see
+#
+# http://creativecommons.org/publicdomain/zero/1.0/
+#
+# ##############################################################################
+# Tries to find the local libsodium installation.
+#
+# On Windows the sodium_DIR environment variable is used as a default hint which
+# can be overridden by setting the corresponding cmake variable.
+#
+# Once done the following variables will be defined:
+#
+# sodium_FOUND sodium_INCLUDE_DIR sodium_LIBRARY_DEBUG sodium_LIBRARY_RELEASE
+# sodium_VERSION_STRING
+#
+# Furthermore an imported "sodium" target is created.
+#
+
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
+  set(_GCC_COMPATIBLE 1)
+endif()
+
+# static library option
+if(NOT DEFINED sodium_USE_STATIC_LIBS)
+  option(sodium_USE_STATIC_LIBS "enable to statically link against sodium" OFF)
+endif()
+if(NOT (sodium_USE_STATIC_LIBS EQUAL sodium_USE_STATIC_LIBS_LAST))
+  unset(sodium_LIBRARY CACHE)
+  unset(sodium_LIBRARY_DEBUG CACHE)
+  unset(sodium_LIBRARY_RELEASE CACHE)
+  unset(sodium_DLL_DEBUG CACHE)
+  unset(sodium_DLL_RELEASE CACHE)
+  set(sodium_USE_STATIC_LIBS_LAST
+      ${sodium_USE_STATIC_LIBS}
+      CACHE INTERNAL "internal change tracking variable")
+endif()
+
+# ##############################################################################
+# UNIX
+if(UNIX)
+  # import pkg-config
+  find_package(PkgConfig QUIET)
+  if(PKG_CONFIG_FOUND)
+    pkg_check_modules(sodium_PKG QUIET libsodium)
+  endif()
+
+  if(sodium_USE_STATIC_LIBS)
+    if(sodium_PKG_STATIC_LIBRARIES)
+      foreach(_libname ${sodium_PKG_STATIC_LIBRARIES})
+        if(NOT _libname MATCHES "^lib.*\\.a$") # ignore strings already ending
+                                               # with .a
+          list(INSERT sodium_PKG_STATIC_LIBRARIES 0 "lib${_libname}.a")
+        endif()
+      endforeach()
+      list(REMOVE_DUPLICATES sodium_PKG_STATIC_LIBRARIES)
+    else()
+      # if pkgconfig for libsodium doesn't provide static lib info, then
+      # override PKG_STATIC here..
+      set(sodium_PKG_STATIC_LIBRARIES libsodium.a)
+    endif()
+
+    set(XPREFIX sodium_PKG_STATIC)
+  else()
+    if(sodium_PKG_LIBRARIES STREQUAL "")
+      set(sodium_PKG_LIBRARIES sodium)
+    endif()
+
+    set(XPREFIX sodium_PKG)
+  endif()
+
+  find_path(sodium_INCLUDE_DIR sodium.h HINTS ${${XPREFIX}_INCLUDE_DIRS})
+  find_library(sodium_LIBRARY_DEBUG
+               NAMES ${${XPREFIX}_LIBRARIES}
+               HINTS ${${XPREFIX}_LIBRARY_DIRS})
+  find_library(sodium_LIBRARY_RELEASE
+               NAMES ${${XPREFIX}_LIBRARIES}
+               HINTS ${${XPREFIX}_LIBRARY_DIRS})
+
+  # ############################################################################
+  # Windows
+elseif(WIN32)
+  set(sodium_DIR "$ENV{sodium_DIR}" CACHE FILEPATH "sodium install directory")
+  mark_as_advanced(sodium_DIR)
+
+  find_path(sodium_INCLUDE_DIR sodium.h
+            HINTS
+                ${CMAKE_SOURCE_DIR}/lib/include
+                ${sodium_DIR}
+            PATH_SUFFIXES include)
+
+  if(MSVC)
+    # detect target architecture
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/arch.c" [=[
+            #if defined _M_IX86
+            #error ARCH_VALUE x86_32
+            #elif defined _M_X64
+            #error ARCH_VALUE x86_64
+            #endif
+            #error ARCH_VALUE unknown
+        ]=])
+    try_compile(_UNUSED_VAR "${CMAKE_CURRENT_BINARY_DIR}"
+                "${CMAKE_CURRENT_BINARY_DIR}/arch.c"
+                OUTPUT_VARIABLE _COMPILATION_LOG)
+    string(REGEX
+           REPLACE ".*ARCH_VALUE ([a-zA-Z0-9_]+).*"
+                   "\\1"
+                   _TARGET_ARCH
+                   "${_COMPILATION_LOG}")
+
+    # construct library path
+    if(_TARGET_ARCH STREQUAL "x86_32")
+      string(APPEND _PLATFORM_PATH "Win32")
+    elseif(_TARGET_ARCH STREQUAL "x86_64")
+      string(APPEND _PLATFORM_PATH "x64")
+    else()
+      message(
+        FATAL_ERROR
+          "the ${_TARGET_ARCH} architecture is not supported by Findsodium.cmake."
+        )
+    endif()
+    string(APPEND _PLATFORM_PATH "/$$CONFIG$$")
+
+    if(MSVC_VERSION LESS 1900)
+      math(EXPR _VS_VERSION "${MSVC_VERSION} / 10 - 60")
+    else()
+      math(EXPR _VS_VERSION "${MSVC_VERSION} / 10 - 50")
+    endif()
+    string(APPEND _PLATFORM_PATH "/v${_VS_VERSION}")
+
+    if(sodium_USE_STATIC_LIBS)
+      string(APPEND _PLATFORM_PATH "/static")
+    else()
+      string(APPEND _PLATFORM_PATH "/dynamic")
+    endif()
+
+    string(REPLACE "$$CONFIG$$"
+                   "Debug"
+                   _DEBUG_PATH_SUFFIX
+                   "${_PLATFORM_PATH}")
+    string(REPLACE "$$CONFIG$$"
+                   "Release"
+                   _RELEASE_PATH_SUFFIX
+                   "${_PLATFORM_PATH}")
+
+    find_library(sodium_LIBRARY_DEBUG libsodium.lib
+                 HINTS
+                    ${CMAKE_SOURCE_DIR}/lib/x86_64/windows
+                    ${sodium_DIR}
+                 )
+    find_library(sodium_LIBRARY_RELEASE libsodium.lib
+                 HINTS
+                    ${CMAKE_SOURCE_DIR}/lib/x86_64/windows
+                    ${sodium_DIR}
+                 )
+    if(NOT sodium_USE_STATIC_LIBS)
+      set(CMAKE_FIND_LIBRARY_SUFFIXES_BCK ${CMAKE_FIND_LIBRARY_SUFFIXES})
+      set(CMAKE_FIND_LIBRARY_SUFFIXES ".dll")
+      find_library(sodium_DLL_DEBUG libsodium
+                   HINTS
+                    ${cmake_source_dir}/lib/x86_64/windows
+                    ${sodium_dir}
+                   PATH_SUFFIXES ${_DEBUG_PATH_SUFFIX})
+      find_library(sodium_DLL_RELEASE libsodium
+                   HINTS
+                    ${cmake_source_dir}/lib/x86_64/windows
+                    ${sodium_dir}
+                   PATH_SUFFIXES ${_RELEASE_PATH_SUFFIX})
+      set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES_BCK})
+    endif()
+
+  elseif(_GCC_COMPATIBLE)
+    if(sodium_USE_STATIC_LIBS)
+      find_library(sodium_LIBRARY_DEBUG libsodium.a
+                   HINTS ${sodium_DIR}
+                   PATH_SUFFIXES lib)
+      find_library(sodium_LIBRARY_RELEASE libsodium.a
+                   HINTS ${sodium_DIR}
+                   PATH_SUFFIXES lib)
+    else()
+      find_library(sodium_LIBRARY_DEBUG libsodium.dll.a
+                   HINTS ${sodium_DIR}
+                   PATH_SUFFIXES lib)
+      find_library(sodium_LIBRARY_RELEASE libsodium.dll.a
+                   HINTS ${sodium_DIR}
+                   PATH_SUFFIXES lib)
+
+      file(GLOB _DLL
+           LIST_DIRECTORIES false
+           RELATIVE "${sodium_DIR}/bin"
+           "${sodium_DIR}/bin/libsodium*.dll")
+      find_library(sodium_DLL_DEBUG ${_DLL} libsodium
+                   HINTS ${sodium_DIR}
+                   PATH_SUFFIXES bin)
+      find_library(sodium_DLL_RELEASE ${_DLL} libsodium
+                   HINTS ${sodium_DIR}
+                   PATH_SUFFIXES bin)
+    endif()
+  else()
+    message(FATAL_ERROR "this platform is not supported by FindSodium.cmake")
+  endif()
+
+  # ############################################################################
+  # unsupported
+else()
+  message(FATAL_ERROR "this platform is not supported by FindSodium.cmake")
+endif()
+
+# ##############################################################################
+# common stuff
+
+# extract sodium version
+if(sodium_INCLUDE_DIR)
+  set(_VERSION_HEADER "${sodium_INCLUDE_DIR}/sodium/version.h")
+  if(EXISTS "${_VERSION_HEADER}")
+    file(READ "${_VERSION_HEADER}" _VERSION_HEADER_CONTENT)
+    string(
+      REGEX
+      REPLACE
+        ".*define[ \t]+SODIUM_VERSION_STRING[^\"]+\"([^\"]+)\".*"
+        "\\1"
+        sodium_VERSION_STRING
+        "${_VERSION_HEADER_CONTENT}")
+    set(sodium_VERSION_STRING "${sodium_VERSION_STRING}")
+  endif()
+endif()
+
+# communicate results
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(sodium
+                                  REQUIRED_VARS
+                                  sodium_LIBRARY_RELEASE
+                                  sodium_LIBRARY_DEBUG
+                                  sodium_INCLUDE_DIR
+                                  VERSION_VAR
+                                  sodium_VERSION_STRING)
+
+# mark file paths as advanced
+mark_as_advanced(sodium_INCLUDE_DIR)
+mark_as_advanced(sodium_LIBRARY_DEBUG)
+mark_as_advanced(sodium_LIBRARY_RELEASE)
+if(WIN32)
+  mark_as_advanced(sodium_DLL_DEBUG)
+  mark_as_advanced(sodium_DLL_RELEASE)
+endif()
+
+# create imported target
+if(sodium_USE_STATIC_LIBS)
+  set(_LIB_TYPE STATIC)
+else()
+  set(_LIB_TYPE SHARED)
+endif()
+add_library(sodium ${_LIB_TYPE} IMPORTED)
+
+set_target_properties(sodium
+                      PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+                                 "${sodium_INCLUDE_DIR}"
+                                 IMPORTED_LINK_INTERFACE_LANGUAGES
+                                 "C")
+
+if(sodium_USE_STATIC_LIBS)
+  set_target_properties(sodium
+                        PROPERTIES INTERFACE_COMPILE_DEFINITIONS
+                                   "SODIUM_STATIC"
+                                   IMPORTED_LOCATION
+                                   "${sodium_LIBRARY_RELEASE}"
+                                   IMPORTED_LOCATION_DEBUG
+                                   "${sodium_LIBRARY_DEBUG}")
+else()
+  if(UNIX)
+    set_target_properties(sodium
+                          PROPERTIES IMPORTED_LOCATION
+                                     "${sodium_LIBRARY_RELEASE}"
+                                     IMPORTED_LOCATION_DEBUG
+                                     "${sodium_LIBRARY_DEBUG}")
+  elseif(WIN32)
+    set_target_properties(sodium
+                          PROPERTIES IMPORTED_IMPLIB
+                                     "${sodium_LIBRARY_RELEASE}"
+                                     IMPORTED_IMPLIB_DEBUG
+                                     "${sodium_LIBRARY_DEBUG}")
+    if(NOT (sodium_DLL_DEBUG MATCHES ".*-NOTFOUND"))
+      set_target_properties(sodium
+                            PROPERTIES IMPORTED_LOCATION_DEBUG
+                                       "${sodium_DLL_DEBUG}")
+    endif()
+    if(NOT (sodium_DLL_RELEASE MATCHES ".*-NOTFOUND"))
+      set_target_properties(sodium
+                            PROPERTIES IMPORTED_LOCATION_RELWITHDEBINFO
+                                       "${sodium_DLL_RELEASE}"
+                                       IMPORTED_LOCATION_MINSIZEREL
+                                       "${sodium_DLL_RELEASE}"
+                                       IMPORTED_LOCATION_RELEASE
+                                       "${sodium_DLL_RELEASE}")
+    endif()
+  endif()
+endif()

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -18,12 +18,18 @@ set(PUBLIC_LIBS
     bx
     bimg
     rapidjson
+    yojimbo
+    NoesisGUI
+    FMod
 )
 
 set(PRIVATE_LIBS
     glfw
     stb
 )
+
+find_package(NoesisGUI REQUIRED)
+find_package(FMod REQUIRED)
 
 add_library(knoting ${KNOTING_SOURCES} ${KNOTING_SHADERS})
 
@@ -63,6 +69,7 @@ endforeach()
 
 target_include_directories(knoting PUBLIC ${CMAKE_SOURCE_DIR}/core/inc)
 target_include_directories(knoting PUBLIC ${PHYSX_INCLUDE_DIRS})
+target_include_directories(knoting PUBLIC ${CMAKE_SOURCE_DIR}/third/yojimbo)
 
 if(GLFW_FOUND)
     target_include_directories(knoting PUBLIC ${GLFW_INCLUDE_DIR})
@@ -97,4 +104,24 @@ foreach(SHADER_FILE ${KNOTING_SHADERS})
         GLSL 430
         INCLUDES "${CMAKE_SOURCE_DIR}/res/shaders/"
     )
+endforeach()
+
+# Copy DLLs into dist/bin
+
+if (WIN32)
+    set(KNOTING_LIB_DIR "${CMAKE_SOURCE_DIR}/lib/x86_64/windows")
+    file(GLOB_RECURSE KNOTING_DLLs
+        ${KNOTING_LIB_DIR}/*.dll
+    )
+else()
+    set(KNOTING_LIB_DIR "${CMAKE_SOURCE_DIR}/lib/x86_64/linux")
+    file(GLOB_RECURSE KNOTING_DLLs
+        ${KNOTING_LIB_DIR}/*.so
+    )
+endif()
+
+foreach(_DLL ${KNOTING_DLLs})
+    get_filename_component(FILE_NAME ${_DLL} NAME)
+    set(FILE_NAME "${CMAKE_BINARY_DIR}/dist/bin/${FILE_NAME}")
+    configure_file(${_DLL} ${FILE_NAME} COPYONLY)
 endforeach()

--- a/third/CMakeLists.txt
+++ b/third/CMakeLists.txt
@@ -156,3 +156,28 @@ target_include_directories(stb INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/stb)
 
 set(UUID_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 add_subdirectory(stduuid)
+
+# Yojimbo
+
+set(sodium_USE_STATIC_LIBS SKIP_PERFORMANCE_COMPARISON ON CACHE BOOL "" FORCE)
+find_package(sodium REQUIRED)
+set(MBEDTLS_USE_STATIC_LIBS SKIP_PERFORMANCE_COMPARISON ON CACHE BOOL "" FORCE)
+find_package(MbedTLS REQUIRED)
+
+project(Yojimbo C CXX)
+add_library(yojimbo STATIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/yojimbo/yojimbo.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/yojimbo/tlsf/tlsf.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/yojimbo/netcode.io/netcode.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/yojimbo/reliable.io/reliable.c
+)
+
+target_include_directories(yojimbo PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/yojimbo
+    ${CMAKE_CURRENT_SOURCE_DIR}/yojimbo/netcode.io
+    ${CMAKE_CURRENT_SOURCE_DIR}/yojimbo/reliable.io
+)
+
+target_link_libraries(yojimbo PRIVATE sodium)
+
+target_include_directories(yojimbo PUBLIC ${MBEDTLS_INCLUDE_DIR})


### PR DESCRIPTION
Add:
  - Yojimbo
    - MBedTLS
    - LibSodium
  - NoesisGUI
  - FMod

Except Yojimbo, all of the other libraries are binary only libraries.
We could compile MBedTLS and LibSodium, but for security reasons, it
is preferred to use a pre-compiled binary.

As for NoesisGUI and FMod, they both have custom licenses which
prohibit the distribution of the library binaries.