### PR TITLE
Forward renderer restructure 

### DIFF
--- a/core/inc/knoting/engine.h
+++ b/core/inc/knoting/engine.h
@@ -7,6 +7,7 @@
 
 #include <knoting/asset_manager.h>
 #include <knoting/forward_renderer.h>
+#include <knoting/framebuffer_manager.h>
 #include <knoting/physics.h>
 #include <knoting/subsystem.h>
 #include <knoting/window.h>
@@ -23,6 +24,7 @@ class Engine {
     std::weak_ptr<Window> get_window_module() { return m_windowModule; }
     std::weak_ptr<ForwardRenderer> get_forward_render_module() { return m_forwardRenderModule; }
     std::weak_ptr<Physics> get_physics_module() { return m_physicsModule; }
+    std::weak_ptr<FramebufferManager> get_framebuffer_manager_module() { return m_framebufferManager; }
 
     static std::optional<std::reference_wrapper<Engine>> get_active_engine();
     static void set_active_engine(std::optional<std::reference_wrapper<Engine>> engine);
@@ -40,9 +42,11 @@ class Engine {
 
    private:
     std::vector<std::shared_ptr<Subsystem>> m_engineModules;
+
     std::shared_ptr<Window> m_windowModule;
     std::shared_ptr<ForwardRenderer> m_forwardRenderModule;
     std::shared_ptr<Physics> m_physicsModule;
+    std::shared_ptr<FramebufferManager> m_framebufferManager;
 
     inline static std::optional<std::reference_wrapper<Engine>> s_activeEngine = std::nullopt;
     std::shared_ptr<AssetManager> m_assetManager;

--- a/core/inc/knoting/forward_renderer.h
+++ b/core/inc/knoting/forward_renderer.h
@@ -21,17 +21,26 @@ class ForwardRenderer : public Subsystem {
     ForwardRenderer(Engine& engine);
     ~ForwardRenderer();
 
-    void on_render();
-    void on_post_render();
-
     void on_awake() override;
     void on_update(double m_delta_time) override;
     void on_late_update() override;
     void on_destroy() override;
 
    private:
-    int get_window_width();
-    int get_window_height();
+    // 1) SYSTEM : Shadow pass
+    // 2) SYSTEM : Update Active Camera (Runtime / Editor)
+    // 3) SYSTEM : Depth Pass (No Transparent Objects)
+    // 4) SYSTEM : Color Render Pass
+    // 5) SYSTEM : Skybox Render
+    // 6) SYSTEM : Sorted Transparent Render Pass
+    // 7) SYSTEM : Post Processing Stack
+
+    void shadow_pass();
+    void depth_pass();
+    void color_pass();
+    void skybox_pass();
+    void transparent_pass();
+    void post_process_pass();
 
     Engine& m_engine;
     LightData m_lightData;

--- a/core/inc/knoting/forward_renderer.h
+++ b/core/inc/knoting/forward_renderer.h
@@ -29,9 +29,6 @@ class ForwardRenderer : public Subsystem {
     void on_late_update() override;
     void on_destroy() override;
 
-    void recreate_framebuffer(uint16_t width, uint16_t height, uint16_t id = 0);
-    void clear_framebuffer(uint16_t id = 0);
-
    private:
     int get_window_width();
     int get_window_height();

--- a/core/inc/knoting/framebuffer_manager.h
+++ b/core/inc/knoting/framebuffer_manager.h
@@ -29,13 +29,13 @@ class FramebufferManager : public Subsystem {
     void recreate_framebuffer(int width, int height);
     void clear_all_framebuffers();
 
-    void set_current_view_buffer(FrameBufferType type);
+    //    void set_current_view_buffer(FrameBufferType type);
     bgfx::FrameBufferHandle get_framebuffer(FrameBufferType type);
     std::vector<bgfx::TextureHandle> get_texture_attachments(FrameBufferType type);
 
    private:
     FrameBufferType m_currentViewBuffer = FrameBufferType::Color;
-    std::array<RenderTexture, (size_t)FrameBufferType::LAST> m_renderTextures2;
+    std::array<RenderTexture, (size_t)FrameBufferType::LAST> m_renderTextures;
     Engine& m_engine;
 };
 

--- a/core/inc/knoting/framebuffer_manager.h
+++ b/core/inc/knoting/framebuffer_manager.h
@@ -14,8 +14,6 @@ class Engine;
 
 namespace knot {
 
-// enum class MSAAFlags { NONE, MSAA_X2, MSAA_x4, MSAA_x8, MSAA_x16, LAST };
-
 class FramebufferManager : public Subsystem {
    public:
     explicit FramebufferManager(Engine& engine);
@@ -29,7 +27,6 @@ class FramebufferManager : public Subsystem {
     void recreate_framebuffer(int width, int height);
     void clear_all_framebuffers();
 
-    //    void set_current_view_buffer(FrameBufferType type);
     bgfx::FrameBufferHandle get_framebuffer(FrameBufferType type);
     std::vector<bgfx::TextureHandle> get_texture_attachments(FrameBufferType type);
 

--- a/core/inc/knoting/framebuffer_manager.h
+++ b/core/inc/knoting/framebuffer_manager.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <bgfx/bgfx.h>
+#include <knoting/render_texture.h>
+#include <knoting/subsystem.h>
+#include <knoting/types.h>
+#include <memory>
+
+namespace knot {
+
+class Engine;
+
+}
+
+namespace knot {
+
+// enum class MSAAFlags { NONE, MSAA_X2, MSAA_x4, MSAA_x8, MSAA_x16, LAST };
+
+class FramebufferManager : public Subsystem {
+   public:
+    explicit FramebufferManager(Engine& engine);
+    ~FramebufferManager();
+
+    void on_awake() override;
+    void on_update(double m_delta_time) override;
+    void on_late_update() override;
+    void on_destroy() override;
+
+    void recreate_framebuffer(int width, int height);
+    void clear_all_framebuffers();
+
+   private:
+    std::vector<std::shared_ptr<RenderTexture>> m_renderTextures;
+    Engine& m_engine;
+};
+
+}  // namespace knot

--- a/core/inc/knoting/framebuffer_manager.h
+++ b/core/inc/knoting/framebuffer_manager.h
@@ -29,8 +29,13 @@ class FramebufferManager : public Subsystem {
     void recreate_framebuffer(int width, int height);
     void clear_all_framebuffers();
 
+    void set_current_view_buffer(FrameBufferType type);
+    bgfx::FrameBufferHandle get_framebuffer(FrameBufferType type);
+    std::vector<bgfx::TextureHandle> get_texture_attachments(FrameBufferType type);
+
    private:
-    std::vector<std::shared_ptr<RenderTexture>> m_renderTextures;
+    FrameBufferType m_currentViewBuffer = FrameBufferType::Color;
+    std::array<RenderTexture, (size_t)FrameBufferType::LAST> m_renderTextures2;
     Engine& m_engine;
 };
 

--- a/core/inc/knoting/render_texture.h
+++ b/core/inc/knoting/render_texture.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <bgfx/bgfx.h>
+#include <knoting/types.h>
+
+namespace knot {
+
+class RenderTexture {
+   public:
+    void create_render_texture(const FrameBufferType& id, const vec2i& size, const uint64_t& flags);
+    void create_depth_texture(const FrameBufferType& id, const vec2i& size, const uint64_t& flags);
+
+    void update_state(const uint64_t& state);
+    void set_state();
+    void set_view_projection(const mat4& view, const mat4& projection);
+
+    void recreate_render_texture(int width, int height);
+    void destroy();
+    bool is_using_window_size() { return m_useWindowSize; };
+    void clear_framebuffer();
+
+   private:
+    vec2i m_size;
+    bool m_useWindowSize = true;
+
+    uint64_t m_state;
+    uint64_t m_flags;
+    uint16_t m_id;
+
+    bgfx::FrameBufferHandle m_framebufferHandle;
+    std::vector<bgfx::TextureHandle> m_renderTextureHandle;
+
+    static constexpr uint32_t m_clearColor = 0x303030ff;
+};
+
+}  // namespace knot

--- a/core/inc/knoting/render_texture.h
+++ b/core/inc/knoting/render_texture.h
@@ -9,6 +9,7 @@ class RenderTexture {
    public:
     void create_render_texture(const vec2i& size, const uint64_t& flags, const bool useWindowSize = true);
     void create_depth_texture(const vec2i& size, const uint64_t& flags, const bool useWindowSize = true);
+    void create_color_texture(const vec2i& size, const uint64_t& flags, const bool useWindowSize = true);
 
     void update_state(const uint64_t& state);
     void set_state();

--- a/core/inc/knoting/render_texture.h
+++ b/core/inc/knoting/render_texture.h
@@ -7,8 +7,8 @@ namespace knot {
 
 class RenderTexture {
    public:
-    void create_render_texture(const FrameBufferType& id, const vec2i& size, const uint64_t& flags);
-    void create_depth_texture(const FrameBufferType& id, const vec2i& size, const uint64_t& flags);
+    void create_render_texture(const vec2i& size, const uint64_t& flags, const bool useWindowSize = true);
+    void create_depth_texture(const vec2i& size, const uint64_t& flags, const bool useWindowSize = true);
 
     void update_state(const uint64_t& state);
     void set_state();
@@ -18,6 +18,9 @@ class RenderTexture {
     void destroy();
     bool is_using_window_size() { return m_useWindowSize; };
     void clear_framebuffer();
+
+    bgfx::FrameBufferHandle get_framebuffer() { return m_framebufferHandle; };
+    std::vector<bgfx::TextureHandle> get_texture_attachments() { return m_renderTextureHandle; };
 
    private:
     vec2i m_size;

--- a/core/inc/knoting/types.h
+++ b/core/inc/knoting/types.h
@@ -23,14 +23,15 @@ enum class SkyBoxTextureType { SkyBox, Irradiance, Radiance, LAST };
 }  // namespace asset
 
 enum class FrameBufferType : uint16_t {
+    Back,
     Depth,
     Color,
     PostProcess,
+    Gui,
     ShadowOne,
     ShadowTwo,
     ShadowThree,
     ShadowFour,
-    Editor,
     LAST
 };
 

--- a/core/inc/knoting/types.h
+++ b/core/inc/knoting/types.h
@@ -22,6 +22,18 @@ enum class SkyBoxTextureType { SkyBox, Irradiance, Radiance, LAST };
 
 }  // namespace asset
 
+enum class FrameBufferType : uint16_t {
+    Depth,
+    Color,
+    PostProcess,
+    ShadowOne,
+    ShadowTwo,
+    ShadowThree,
+    ShadowFour,
+    Editor,
+    LAST
+};
+
 using namespace glm;
 using namespace uuids;
 

--- a/core/inc/knoting/window.h
+++ b/core/inc/knoting/window.h
@@ -34,6 +34,7 @@ class Window : public Subsystem {
     int get_window_width() { return m_width; };
     int get_window_height() { return m_height; };
     void set_window_size(vec2i size);
+    vec2i get_window_size() { return vec2i(m_width, m_height); };
 
     float get_mouse_change_x() { return m_mouseWheelH; };
     float get_mouse_change_y() { return m_mouseWheel; };

--- a/core/src/engine.cpp
+++ b/core/src/engine.cpp
@@ -39,17 +39,14 @@ void Engine::update_modules() {
     // SCRIPTS
     // 1) SYSTEM : Editor Camera movement
 
-    // PBR RENDERING
+    // RENDERING
     // 1) SYSTEM : Shadow pass
     // 2) SYSTEM : Update Active Camera (Runtime / Editor)
     // 3) SYSTEM : Depth Pass (No Transparent Objects)
-    // 4) SYSTEM : PBR Render Pass
+    // 4) SYSTEM : Color Render Pass
     // 5) SYSTEM : Skybox Render
     // 6) SYSTEM : Sorted Transparent Render Pass
     // 7) SYSTEM : Post Processing Stack
-
-    m_forwardRenderModule->on_render();
-    m_forwardRenderModule->on_post_render();
 
     for (auto& module : m_engineModules) {
         module->on_late_update();

--- a/core/src/engine.cpp
+++ b/core/src/engine.cpp
@@ -4,12 +4,14 @@
 namespace knot {
 
 Engine::Engine() {
+    m_framebufferManager = std::make_shared<knot::FramebufferManager>(*this);
     m_windowModule = std::make_shared<knot::Window>(m_windowWidth, m_windowHeight, m_windowTitle, *this);
     m_forwardRenderModule = std::make_shared<knot::ForwardRenderer>(*this);
     m_physicsModule = std::make_shared<knot::Physics>(*this);
     m_assetManager = std::make_shared<knot::AssetManager>();
 
     // order dependent
+    m_engineModules.emplace_back(m_framebufferManager);
     m_engineModules.emplace_back(m_windowModule);
     m_engineModules.emplace_back(m_assetManager);
     m_engineModules.emplace_back(m_forwardRenderModule);

--- a/core/src/forward_renderer.cpp
+++ b/core/src/forward_renderer.cpp
@@ -24,6 +24,8 @@ void ForwardRenderer::on_awake() {}
 
 void ForwardRenderer::on_update(double m_delta_time) {
     m_timePassed += (float)m_delta_time;
+    bgfx::touch(0);
+
     shadow_pass();
     depth_pass();
     color_pass();
@@ -40,10 +42,7 @@ void ForwardRenderer::color_pass() {
     m_engine.get_framebuffer_manager_module().lock()->clear_all_framebuffers();
     auto fbos = m_engine.get_framebuffer_manager_module().lock();
     auto colorBuffer = fbos->get_framebuffer(FrameBufferType::Color);
-    auto idx = 0;  // Backbuffer
-    //    auto idx = colorBuffer.idx; //TODO check what is render to this buffer via render doc as no editor debugging
-    //    currently available
-    bgfx::touch(idx);
+    auto idx = colorBuffer.idx;  // TODO check what is render to this buffer via render doc as no editor debugging
 
     auto sceneOpt = Scene::get_active_scene();
     if (!sceneOpt) {
@@ -165,7 +164,6 @@ void ForwardRenderer::color_pass() {
 
         bgfx::submit(idx, material.get_program());
     }
-    bgfx::touch(0);
 }
 
 void ForwardRenderer::skybox_pass() {}

--- a/core/src/forward_renderer.cpp
+++ b/core/src/forward_renderer.cpp
@@ -22,7 +22,7 @@ ForwardRenderer::ForwardRenderer(Engine& engine) : m_engine(engine) {}
 
 void ForwardRenderer::on_render() {
     using namespace components;
-    clear_framebuffer();
+    m_engine.get_framebuffer_manager_module().lock()->clear_all_framebuffers();
     bgfx::touch(0);
 
     auto sceneOpt = Scene::get_active_scene();
@@ -139,7 +139,6 @@ void ForwardRenderer::on_render() {
         // Bind Uniforms & textures.
         material.set_uniforms();
 
-        // TODO enable MSAA in bgfx
         bgfx::setState(0 | BGFX_STATE_MSAA | BGFX_STATE_WRITE_RGB | BGFX_STATE_WRITE_A | BGFX_STATE_WRITE_Z |
                        BGFX_STATE_DEPTH_TEST_LESS);
 
@@ -158,16 +157,6 @@ void ForwardRenderer::on_update(double m_delta_time) {
 void ForwardRenderer::on_late_update() {}
 
 void ForwardRenderer::on_destroy() {}
-
-void ForwardRenderer::recreate_framebuffer(uint16_t width, uint16_t height, uint16_t id) {
-    bgfx::reset((uint32_t)width, (uint32_t)height, BGFX_RESET_VSYNC | BGFX_RESET_MSAA_X2);
-    bgfx::setViewClear(id, BGFX_CLEAR_COLOR | BGFX_CLEAR_DEPTH | BGFX_CLEAR_STENCIL, (uint32_t)m_clearColor);
-    bgfx::setViewRect(id, 0, 0, width, height);
-}
-
-void ForwardRenderer::clear_framebuffer(uint16_t id) {
-    bgfx::setViewClear(id, BGFX_CLEAR_COLOR | BGFX_CLEAR_DEPTH, (uint32_t)m_clearColor);
-}
 
 int ForwardRenderer::get_window_width() {
     return m_engine.get_window_module().lock()->get_window_width();

--- a/core/src/framebuffer_manager.cpp
+++ b/core/src/framebuffer_manager.cpp
@@ -1,0 +1,52 @@
+#include "knoting/framebuffer_manager.h"
+#include <knoting/log.h>
+
+namespace knot {
+
+FramebufferManager::FramebufferManager(Engine& engine) : m_engine(engine) {}
+
+void FramebufferManager::on_awake() {
+    uint64_t colorState = 0;
+    colorState =
+        BGFX_STATE_MSAA | BGFX_STATE_WRITE_RGB | BGFX_STATE_WRITE_A | BGFX_STATE_WRITE_Z | BGFX_STATE_DEPTH_TEST_LESS;
+
+    uint64_t depthState = 0;
+    depthState = BGFX_STATE_WRITE_Z | BGFX_STATE_DEPTH_TEST_LEQUAL;
+
+    auto colorRT = std::make_shared<RenderTexture>();
+    auto depthRT = std::make_shared<RenderTexture>();
+
+    colorRT->create_render_texture(FrameBufferType::Color, vec2i(1024), 0);
+    depthRT->create_depth_texture(FrameBufferType::Depth, vec2i(1024), 0);
+    colorRT->update_state(colorState);
+    depthRT->update_state(depthState);
+
+    m_renderTextures.emplace_back(colorRT);
+    m_renderTextures.emplace_back(depthRT);
+}
+
+void FramebufferManager::on_update(double m_delta_time) {}
+void FramebufferManager::on_late_update() {}
+
+void FramebufferManager::on_destroy() {
+    for (auto& rt : m_renderTextures) {
+        rt->destroy();
+    }
+    m_renderTextures.clear();
+    log::info("FramebufferManager destroyed");
+}
+FramebufferManager::~FramebufferManager() {}
+void FramebufferManager::recreate_framebuffer(int width, int height) {
+    for (auto& rt : m_renderTextures) {
+        if (rt->is_using_window_size()) {
+            rt->recreate_render_texture(width, height);
+        }
+    }
+}
+void FramebufferManager::clear_all_framebuffers() {
+    for (auto& rt : m_renderTextures) {
+        rt->clear_framebuffer();
+    }
+}
+
+}  // namespace knot

--- a/core/src/framebuffer_manager.cpp
+++ b/core/src/framebuffer_manager.cpp
@@ -12,32 +12,39 @@ void FramebufferManager::on_awake() {
 
     uint64_t depthState = 0 | BGFX_STATE_WRITE_Z | BGFX_STATE_DEPTH_TEST_LEQUAL;
 
-    m_renderTextures2[(size_t)FrameBufferType::Depth] = RenderTexture();
-    m_renderTextures2[(size_t)FrameBufferType::Color] = RenderTexture();
-    m_renderTextures2[(size_t)FrameBufferType::PostProcess] = RenderTexture();
-    m_renderTextures2[(size_t)FrameBufferType::ShadowOne] = RenderTexture();
-    m_renderTextures2[(size_t)FrameBufferType::ShadowTwo] = RenderTexture();
-    m_renderTextures2[(size_t)FrameBufferType::ShadowThree] = RenderTexture();
-    m_renderTextures2[(size_t)FrameBufferType::ShadowFour] = RenderTexture();
-    m_renderTextures2[(size_t)FrameBufferType::Editor] = RenderTexture();
+    auto windowSize = m_engine.get_window_module().lock()->get_window_size();
 
-    m_renderTextures2[(size_t)FrameBufferType::Depth].create_depth_texture(vec2i(1024), 0);
-    m_renderTextures2[(size_t)FrameBufferType::Color].create_render_texture(vec2i(1024), 0);
-    m_renderTextures2[(size_t)FrameBufferType::PostProcess].create_render_texture(vec2i(1024), 0);
-    m_renderTextures2[(size_t)FrameBufferType::ShadowOne].create_depth_texture(vec2i(512), 0, false);
-    m_renderTextures2[(size_t)FrameBufferType::ShadowTwo].create_depth_texture(vec2i(512), 0, false);
-    m_renderTextures2[(size_t)FrameBufferType::ShadowThree].create_depth_texture(vec2i(512), 0, false);
-    m_renderTextures2[(size_t)FrameBufferType::ShadowFour].create_depth_texture(vec2i(512), 0, false);
-    m_renderTextures2[(size_t)FrameBufferType::Editor].create_render_texture(vec2i(512), 0);
+    m_renderTextures[(size_t)FrameBufferType::Back] = RenderTexture();
+    m_renderTextures[(size_t)FrameBufferType::Depth] = RenderTexture();
+    m_renderTextures[(size_t)FrameBufferType::Color] = RenderTexture();
+    m_renderTextures[(size_t)FrameBufferType::PostProcess] = RenderTexture();
+    m_renderTextures[(size_t)FrameBufferType::Gui] = RenderTexture();
+    m_renderTextures[(size_t)FrameBufferType::ShadowOne] = RenderTexture();
+    m_renderTextures[(size_t)FrameBufferType::ShadowTwo] = RenderTexture();
+    m_renderTextures[(size_t)FrameBufferType::ShadowThree] = RenderTexture();
+    m_renderTextures[(size_t)FrameBufferType::ShadowFour] = RenderTexture();
 
-    m_renderTextures2[(size_t)FrameBufferType::Depth].update_state(depthState);
-    m_renderTextures2[(size_t)FrameBufferType::Color].update_state(colorState);
-    m_renderTextures2[(size_t)FrameBufferType::PostProcess].update_state(colorState);
-    m_renderTextures2[(size_t)FrameBufferType::ShadowOne].update_state(depthState);
-    m_renderTextures2[(size_t)FrameBufferType::ShadowTwo].update_state(depthState);
-    m_renderTextures2[(size_t)FrameBufferType::ShadowThree].update_state(depthState);
-    m_renderTextures2[(size_t)FrameBufferType::ShadowFour].update_state(depthState);
-    m_renderTextures2[(size_t)FrameBufferType::Editor].update_state(colorState);
+    m_renderTextures[(size_t)FrameBufferType::Back].create_color_texture(windowSize, 0);
+    m_renderTextures[(size_t)FrameBufferType::Depth].create_depth_texture(windowSize, 0);
+    m_renderTextures[(size_t)FrameBufferType::Color].create_render_texture(windowSize, 0);
+    m_renderTextures[(size_t)FrameBufferType::PostProcess].create_render_texture(windowSize, 0);
+    m_renderTextures[(size_t)FrameBufferType::Gui].create_render_texture(windowSize, 0);
+    m_renderTextures[(size_t)FrameBufferType::ShadowOne].create_depth_texture(vec2i(512), 0, false);
+    m_renderTextures[(size_t)FrameBufferType::ShadowTwo].create_depth_texture(vec2i(512), 0, false);
+    m_renderTextures[(size_t)FrameBufferType::ShadowThree].create_depth_texture(vec2i(512), 0, false);
+    m_renderTextures[(size_t)FrameBufferType::ShadowFour].create_depth_texture(vec2i(512), 0, false);
+
+    m_renderTextures[(size_t)FrameBufferType::Back].update_state(depthState);
+    m_renderTextures[(size_t)FrameBufferType::Depth].update_state(depthState);
+    m_renderTextures[(size_t)FrameBufferType::Color].update_state(colorState);
+    m_renderTextures[(size_t)FrameBufferType::PostProcess].update_state(colorState);
+    m_renderTextures[(size_t)FrameBufferType::Gui].update_state(colorState);
+    m_renderTextures[(size_t)FrameBufferType::ShadowOne].update_state(depthState);
+    m_renderTextures[(size_t)FrameBufferType::ShadowTwo].update_state(depthState);
+    m_renderTextures[(size_t)FrameBufferType::ShadowThree].update_state(depthState);
+    m_renderTextures[(size_t)FrameBufferType::ShadowFour].update_state(depthState);
+
+    recreate_framebuffer(windowSize.x, windowSize.y);
 }
 
 void FramebufferManager::on_update(double m_delta_time) {}
@@ -48,45 +55,112 @@ void FramebufferManager::on_destroy() {
 }
 FramebufferManager::~FramebufferManager() {}
 void FramebufferManager::recreate_framebuffer(int width, int height) {
-    for (auto& rt : m_renderTextures2) {
+    log::warn("recreate fbos {}, {}", width, height);
+    auto windowSize = m_engine.get_window_module().lock()->get_window_size();
+
+    {
+        auto backFB = m_renderTextures[(size_t)FrameBufferType::Back].get_framebuffer();
+        bgfx::setViewName(backFB.idx, "back buffer");
+        bgfx::setViewClear(backFB.idx, BGFX_CLEAR_COLOR | BGFX_CLEAR_DEPTH, 0x303030ff, 1.0f, 0);
+        bgfx::setViewRect(backFB.idx, 0, 0, bgfx::BackbufferRatio::Equal);
+        bgfx::setViewFrameBuffer(backFB.idx, backFB);
+    }
+    {
+        auto depthFB = m_renderTextures[(size_t)FrameBufferType::Depth].get_framebuffer();
+        bgfx::setViewName(depthFB.idx, "depth pass");
+        bgfx::setViewClear(depthFB.idx, BGFX_CLEAR_DEPTH, 0x303030ff, 1.0f, 0);
+        bgfx::setViewRect(depthFB.idx, 0, 0, windowSize.x, windowSize.y);
+        bgfx::setViewFrameBuffer(depthFB.idx, depthFB);
+    }
+    {
+        auto colorFB = m_renderTextures[(size_t)FrameBufferType::Color].get_framebuffer();
+        bgfx::setViewName(colorFB.idx, "color pass");
+        bgfx::setViewClear(colorFB.idx, BGFX_CLEAR_COLOR | BGFX_CLEAR_DEPTH, 0x303030ff, 1.0f, 0);
+        bgfx::setViewRect(colorFB.idx, 0, 0, windowSize.x, windowSize.y);
+        bgfx::setViewFrameBuffer(colorFB.idx, colorFB);
+    }
+    {
+        auto postProcessFB = m_renderTextures[(size_t)FrameBufferType::PostProcess].get_framebuffer();
+        bgfx::setViewName(postProcessFB.idx, "post process pass");
+        bgfx::setViewClear(postProcessFB.idx, BGFX_CLEAR_COLOR | BGFX_CLEAR_DEPTH, 0x303030ff, 1.0f, 0);
+        bgfx::setViewRect(postProcessFB.idx, 0, 0, windowSize.x, windowSize.y);
+        bgfx::setViewFrameBuffer(postProcessFB.idx, postProcessFB);
+    }
+    {
+        auto guiFB = m_renderTextures[(size_t)FrameBufferType::Gui].get_framebuffer();
+        bgfx::setViewName(guiFB.idx, "gui pass");
+        bgfx::setViewClear(guiFB.idx, BGFX_CLEAR_COLOR | BGFX_CLEAR_DEPTH, 0x303030ff, 1.0f, 0);
+        bgfx::setViewRect(guiFB.idx, 0, 0, windowSize.x, windowSize.y);
+        bgfx::setViewFrameBuffer(guiFB.idx, guiFB);
+    }
+    {
+        auto shadowOneFB = m_renderTextures[(size_t)FrameBufferType::ShadowOne].get_framebuffer();
+        bgfx::setViewName(shadowOneFB.idx, "shadow one pass");
+        bgfx::setViewClear(shadowOneFB.idx, BGFX_CLEAR_DEPTH, 0x303030ff, 1.0f, 0);
+        bgfx::setViewRect(shadowOneFB.idx, 0, 0, 512, 512);
+        bgfx::setViewFrameBuffer(shadowOneFB.idx, shadowOneFB);
+    }
+    {
+        auto shadowTwoFB = m_renderTextures[(size_t)FrameBufferType::ShadowTwo].get_framebuffer();
+        bgfx::setViewName(shadowTwoFB.idx, "shadow two pass");
+        bgfx::setViewClear(shadowTwoFB.idx, BGFX_CLEAR_DEPTH, 0x303030ff, 1.0f, 0);
+        bgfx::setViewRect(shadowTwoFB.idx, 0, 0, 512, 512);
+        bgfx::setViewFrameBuffer(shadowTwoFB.idx, shadowTwoFB);
+    }
+    {
+        auto shadowThreeFB = m_renderTextures[(size_t)FrameBufferType::ShadowThree].get_framebuffer();
+        bgfx::setViewName(shadowThreeFB.idx, "shadow three pass");
+        bgfx::setViewClear(shadowThreeFB.idx, BGFX_CLEAR_DEPTH, 0x303030ff, 1.0f, 0);
+        bgfx::setViewRect(shadowThreeFB.idx, 0, 0, 512, 512);
+        bgfx::setViewFrameBuffer(shadowThreeFB.idx, shadowThreeFB);
+    }
+    {
+        auto shadowFourFB = m_renderTextures[(size_t)FrameBufferType::ShadowFour].get_framebuffer();
+        bgfx::setViewName(shadowFourFB.idx, "shadow four pass");
+        bgfx::setViewClear(shadowFourFB.idx, BGFX_CLEAR_DEPTH, 0x303030ff, 1.0f, 0);
+        bgfx::setViewRect(shadowFourFB.idx, 0, 0, 512, 512);
+        bgfx::setViewFrameBuffer(shadowFourFB.idx, shadowFourFB);
+    }
+
+    for (auto& rt : m_renderTextures) {
         if (rt.is_using_window_size()) {
             rt.recreate_render_texture(width, height);
         }
     }
 
-    bgfx::ViewId order[] = {m_renderTextures2[(size_t)FrameBufferType::Depth].get_framebuffer().idx,
-                            m_renderTextures2[(size_t)FrameBufferType::Color].get_framebuffer().idx,
-                            m_renderTextures2[(size_t)FrameBufferType::PostProcess].get_framebuffer().idx,
-                            m_renderTextures2[(size_t)FrameBufferType::ShadowOne].get_framebuffer().idx,
-                            m_renderTextures2[(size_t)FrameBufferType::ShadowTwo].get_framebuffer().idx,
-                            m_renderTextures2[(size_t)FrameBufferType::ShadowThree].get_framebuffer().idx,
-                            m_renderTextures2[(size_t)FrameBufferType::ShadowFour].get_framebuffer().idx,
-                            m_renderTextures2[(size_t)FrameBufferType::Editor].get_framebuffer().idx};
+    bgfx::ViewId order[] = {m_renderTextures[(size_t)FrameBufferType::Back].get_framebuffer().idx,
+                            m_renderTextures[(size_t)FrameBufferType::Depth].get_framebuffer().idx,
+                            m_renderTextures[(size_t)FrameBufferType::Color].get_framebuffer().idx,
+                            m_renderTextures[(size_t)FrameBufferType::PostProcess].get_framebuffer().idx,
+                            m_renderTextures[(size_t)FrameBufferType::Gui].get_framebuffer().idx,
+                            m_renderTextures[(size_t)FrameBufferType::ShadowOne].get_framebuffer().idx,
+                            m_renderTextures[(size_t)FrameBufferType::ShadowTwo].get_framebuffer().idx,
+                            m_renderTextures[(size_t)FrameBufferType::ShadowThree].get_framebuffer().idx,
+                            m_renderTextures[(size_t)FrameBufferType::ShadowFour].get_framebuffer().idx};
 
-    bgfx::setViewOrder(0, m_renderTextures2.size(), order);
+    bgfx::setViewOrder(0, m_renderTextures.size(), order);
 
+    //
     bgfx::setViewFrameBuffer((size_t)m_currentViewBuffer,
-                             m_renderTextures2[(size_t)m_currentViewBuffer].get_framebuffer());
+                             m_renderTextures[(size_t)m_currentViewBuffer].get_framebuffer());
 }
-
-void FramebufferManager::set_current_view_buffer(FrameBufferType type) {
-    m_currentViewBuffer = type;
-    auto window = m_engine.get_window_module().lock();
-    vec2i size = window->get_window_size();
-    window->recreate_framebuffer(size.x, size.y);
-}
+// void FramebufferManager::set_current_view_buffer(FrameBufferType type) {
+//     m_currentViewBuffer = type;
+//     bgfx::setViewFrameBuffer((size_t)m_currentViewBuffer,
+//                              m_renderTextures[(size_t)m_currentViewBuffer].get_framebuffer());
+// }
 
 void FramebufferManager::clear_all_framebuffers() {
-    for (auto& rt : m_renderTextures2) {
+    for (auto& rt : m_renderTextures) {
         rt.clear_framebuffer();
     }
 }
 bgfx::FrameBufferHandle FramebufferManager::get_framebuffer(FrameBufferType type) {
-    return m_renderTextures2[(size_t)type].get_framebuffer();
+    return m_renderTextures[(size_t)type].get_framebuffer();
 }
 
 std::vector<bgfx::TextureHandle> FramebufferManager::get_texture_attachments(FrameBufferType type) {
-    return m_renderTextures2[(size_t)type].get_texture_attachments();
+    return m_renderTextures[(size_t)type].get_texture_attachments();
 }
 
 }  // namespace knot

--- a/core/src/framebuffer_manager.cpp
+++ b/core/src/framebuffer_manager.cpp
@@ -1,4 +1,5 @@
 #include "knoting/framebuffer_manager.h"
+#include <knoting/engine.h>
 #include <knoting/log.h>
 
 namespace knot {
@@ -6,47 +7,86 @@ namespace knot {
 FramebufferManager::FramebufferManager(Engine& engine) : m_engine(engine) {}
 
 void FramebufferManager::on_awake() {
-    uint64_t colorState = 0;
-    colorState =
-        BGFX_STATE_MSAA | BGFX_STATE_WRITE_RGB | BGFX_STATE_WRITE_A | BGFX_STATE_WRITE_Z | BGFX_STATE_DEPTH_TEST_LESS;
+    uint64_t colorState = 0 | BGFX_STATE_MSAA | BGFX_STATE_WRITE_RGB | BGFX_STATE_WRITE_A | BGFX_STATE_WRITE_Z |
+                          BGFX_STATE_DEPTH_TEST_LESS;
 
-    uint64_t depthState = 0;
-    depthState = BGFX_STATE_WRITE_Z | BGFX_STATE_DEPTH_TEST_LEQUAL;
+    uint64_t depthState = 0 | BGFX_STATE_WRITE_Z | BGFX_STATE_DEPTH_TEST_LEQUAL;
 
-    auto colorRT = std::make_shared<RenderTexture>();
-    auto depthRT = std::make_shared<RenderTexture>();
+    m_renderTextures2[(size_t)FrameBufferType::Depth] = RenderTexture();
+    m_renderTextures2[(size_t)FrameBufferType::Color] = RenderTexture();
+    m_renderTextures2[(size_t)FrameBufferType::PostProcess] = RenderTexture();
+    m_renderTextures2[(size_t)FrameBufferType::ShadowOne] = RenderTexture();
+    m_renderTextures2[(size_t)FrameBufferType::ShadowTwo] = RenderTexture();
+    m_renderTextures2[(size_t)FrameBufferType::ShadowThree] = RenderTexture();
+    m_renderTextures2[(size_t)FrameBufferType::ShadowFour] = RenderTexture();
+    m_renderTextures2[(size_t)FrameBufferType::Editor] = RenderTexture();
 
-    colorRT->create_render_texture(FrameBufferType::Color, vec2i(1024), 0);
-    depthRT->create_depth_texture(FrameBufferType::Depth, vec2i(1024), 0);
-    colorRT->update_state(colorState);
-    depthRT->update_state(depthState);
+    m_renderTextures2[(size_t)FrameBufferType::Depth].create_depth_texture(vec2i(1024), 0);
+    m_renderTextures2[(size_t)FrameBufferType::Color].create_render_texture(vec2i(1024), 0);
+    m_renderTextures2[(size_t)FrameBufferType::PostProcess].create_render_texture(vec2i(1024), 0);
+    m_renderTextures2[(size_t)FrameBufferType::ShadowOne].create_depth_texture(vec2i(512), 0, false);
+    m_renderTextures2[(size_t)FrameBufferType::ShadowTwo].create_depth_texture(vec2i(512), 0, false);
+    m_renderTextures2[(size_t)FrameBufferType::ShadowThree].create_depth_texture(vec2i(512), 0, false);
+    m_renderTextures2[(size_t)FrameBufferType::ShadowFour].create_depth_texture(vec2i(512), 0, false);
+    m_renderTextures2[(size_t)FrameBufferType::Editor].create_render_texture(vec2i(512), 0);
 
-    m_renderTextures.emplace_back(colorRT);
-    m_renderTextures.emplace_back(depthRT);
+    m_renderTextures2[(size_t)FrameBufferType::Depth].update_state(depthState);
+    m_renderTextures2[(size_t)FrameBufferType::Color].update_state(colorState);
+    m_renderTextures2[(size_t)FrameBufferType::PostProcess].update_state(colorState);
+    m_renderTextures2[(size_t)FrameBufferType::ShadowOne].update_state(depthState);
+    m_renderTextures2[(size_t)FrameBufferType::ShadowTwo].update_state(depthState);
+    m_renderTextures2[(size_t)FrameBufferType::ShadowThree].update_state(depthState);
+    m_renderTextures2[(size_t)FrameBufferType::ShadowFour].update_state(depthState);
+    m_renderTextures2[(size_t)FrameBufferType::Editor].update_state(colorState);
 }
 
 void FramebufferManager::on_update(double m_delta_time) {}
 void FramebufferManager::on_late_update() {}
 
 void FramebufferManager::on_destroy() {
-    for (auto& rt : m_renderTextures) {
-        rt->destroy();
-    }
-    m_renderTextures.clear();
     log::info("FramebufferManager destroyed");
 }
 FramebufferManager::~FramebufferManager() {}
 void FramebufferManager::recreate_framebuffer(int width, int height) {
-    for (auto& rt : m_renderTextures) {
-        if (rt->is_using_window_size()) {
-            rt->recreate_render_texture(width, height);
+    for (auto& rt : m_renderTextures2) {
+        if (rt.is_using_window_size()) {
+            rt.recreate_render_texture(width, height);
         }
     }
+
+    bgfx::ViewId order[] = {m_renderTextures2[(size_t)FrameBufferType::Depth].get_framebuffer().idx,
+                            m_renderTextures2[(size_t)FrameBufferType::Color].get_framebuffer().idx,
+                            m_renderTextures2[(size_t)FrameBufferType::PostProcess].get_framebuffer().idx,
+                            m_renderTextures2[(size_t)FrameBufferType::ShadowOne].get_framebuffer().idx,
+                            m_renderTextures2[(size_t)FrameBufferType::ShadowTwo].get_framebuffer().idx,
+                            m_renderTextures2[(size_t)FrameBufferType::ShadowThree].get_framebuffer().idx,
+                            m_renderTextures2[(size_t)FrameBufferType::ShadowFour].get_framebuffer().idx,
+                            m_renderTextures2[(size_t)FrameBufferType::Editor].get_framebuffer().idx};
+
+    bgfx::setViewOrder(0, m_renderTextures2.size(), order);
+
+    bgfx::setViewFrameBuffer((size_t)m_currentViewBuffer,
+                             m_renderTextures2[(size_t)m_currentViewBuffer].get_framebuffer());
 }
+
+void FramebufferManager::set_current_view_buffer(FrameBufferType type) {
+    m_currentViewBuffer = type;
+    auto window = m_engine.get_window_module().lock();
+    vec2i size = window->get_window_size();
+    window->recreate_framebuffer(size.x, size.y);
+}
+
 void FramebufferManager::clear_all_framebuffers() {
-    for (auto& rt : m_renderTextures) {
-        rt->clear_framebuffer();
+    for (auto& rt : m_renderTextures2) {
+        rt.clear_framebuffer();
     }
+}
+bgfx::FrameBufferHandle FramebufferManager::get_framebuffer(FrameBufferType type) {
+    return m_renderTextures2[(size_t)type].get_framebuffer();
+}
+
+std::vector<bgfx::TextureHandle> FramebufferManager::get_texture_attachments(FrameBufferType type) {
+    return m_renderTextures2[(size_t)type].get_texture_attachments();
 }
 
 }  // namespace knot

--- a/core/src/framebuffer_manager.cpp
+++ b/core/src/framebuffer_manager.cpp
@@ -144,11 +144,6 @@ void FramebufferManager::recreate_framebuffer(int width, int height) {
     bgfx::setViewFrameBuffer((size_t)m_currentViewBuffer,
                              m_renderTextures[(size_t)m_currentViewBuffer].get_framebuffer());
 }
-// void FramebufferManager::set_current_view_buffer(FrameBufferType type) {
-//     m_currentViewBuffer = type;
-//     bgfx::setViewFrameBuffer((size_t)m_currentViewBuffer,
-//                              m_renderTextures[(size_t)m_currentViewBuffer].get_framebuffer());
-// }
 
 void FramebufferManager::clear_all_framebuffers() {
     for (auto& rt : m_renderTextures) {

--- a/core/src/render_texture.cpp
+++ b/core/src/render_texture.cpp
@@ -3,7 +3,8 @@
 
 namespace knot {
 
-void RenderTexture::create_render_texture(const FrameBufferType& id, const vec2i& size, const uint64_t& flags) {
+void RenderTexture::create_render_texture(const vec2i& size, const uint64_t& flags, const bool useWindowSize) {
+    m_useWindowSize = useWindowSize;
     m_flags = flags;
 
     bool validFlags = (m_flags & (BGFX_TEXTURE_RT | BGFX_SAMPLER_COMPARE_LESS));
@@ -19,7 +20,8 @@ void RenderTexture::create_render_texture(const FrameBufferType& id, const vec2i
     m_framebufferHandle = bgfx::createFrameBuffer(m_renderTextureHandle.size(), m_renderTextureHandle.data());
 }
 
-void RenderTexture::create_depth_texture(const FrameBufferType& id, const vec2i& size, const uint64_t& flags) {
+void RenderTexture::create_depth_texture(const vec2i& size, const uint64_t& flags, const bool useWindowSize) {
+    m_useWindowSize = useWindowSize;
     m_flags = flags;
 
     bool validFlags = (m_flags & (BGFX_TEXTURE_RT | BGFX_SAMPLER_COMPARE_LEQUAL));
@@ -40,10 +42,6 @@ void RenderTexture::recreate_render_texture(int width, int height) {
     bgfx::reset((uint32_t)width, (uint32_t)height, BGFX_RESET_VSYNC | BGFX_RESET_MSAA_X2);
     bgfx::setViewClear(m_id, BGFX_CLEAR_COLOR | BGFX_CLEAR_DEPTH | BGFX_CLEAR_STENCIL, (uint32_t)m_clearColor);
     bgfx::setViewRect(m_id, 0, 0, width, height);
-    bgfx::setViewFrameBuffer(m_id, BGFX_INVALID_HANDLE);  // DRAW INTO BACK BUFFER
-    // TODO FB MANAGER SET ACTIVE FRAME BUFFER WITH "FrameBufferType"
-    // bgfx::setViewFrameBuffer(m_id, m_framebufferHandle);
-    // TODO SHADER TO PASS FBOS INTO // OR IMGUI IMAGE FOR EACH RT / FBO
 }
 
 void RenderTexture::set_view_projection(const mat4& view, const mat4& projection) {

--- a/core/src/render_texture.cpp
+++ b/core/src/render_texture.cpp
@@ -20,6 +20,20 @@ void RenderTexture::create_render_texture(const vec2i& size, const uint64_t& fla
     m_framebufferHandle = bgfx::createFrameBuffer(m_renderTextureHandle.size(), m_renderTextureHandle.data());
 }
 
+void RenderTexture::create_color_texture(const vec2i& size, const uint64_t& flags, const bool useWindowSize) {
+    m_useWindowSize = useWindowSize;
+    m_flags = flags;
+
+    bool validFlags = (m_flags & (BGFX_TEXTURE_RT | BGFX_SAMPLER_COMPARE_LESS));
+    if (!validFlags) {
+        log::warn("invalid render texture flag using fallback");
+        m_flags = BGFX_TEXTURE_RT | BGFX_SAMPLER_COMPARE_LESS;
+    }
+
+    m_renderTextureHandle.emplace_back(
+        bgfx::createTexture2D(size.x, size.y, false, 1, bgfx::TextureFormat::BGRA8, m_flags));
+}
+
 void RenderTexture::create_depth_texture(const vec2i& size, const uint64_t& flags, const bool useWindowSize) {
     m_useWindowSize = useWindowSize;
     m_flags = flags;

--- a/core/src/render_texture.cpp
+++ b/core/src/render_texture.cpp
@@ -1,0 +1,72 @@
+#include <knoting/log.h>
+#include <knoting/render_texture.h>
+
+namespace knot {
+
+void RenderTexture::create_render_texture(const FrameBufferType& id, const vec2i& size, const uint64_t& flags) {
+    m_flags = flags;
+
+    bool validFlags = (m_flags & (BGFX_TEXTURE_RT | BGFX_SAMPLER_COMPARE_LESS));
+    if (!validFlags) {
+        log::warn("invalid render texture flag using fallback");
+        m_flags = BGFX_TEXTURE_RT | BGFX_SAMPLER_COMPARE_LESS;
+    }
+
+    m_renderTextureHandle.emplace_back(
+        bgfx::createTexture2D(size.x, size.y, false, 1, bgfx::TextureFormat::BGRA8, m_flags));
+    m_renderTextureHandle.emplace_back(
+        bgfx::createTexture2D(size.x, size.y, false, 1, bgfx::TextureFormat::D16, m_flags));
+    m_framebufferHandle = bgfx::createFrameBuffer(m_renderTextureHandle.size(), m_renderTextureHandle.data());
+}
+
+void RenderTexture::create_depth_texture(const FrameBufferType& id, const vec2i& size, const uint64_t& flags) {
+    m_flags = flags;
+
+    bool validFlags = (m_flags & (BGFX_TEXTURE_RT | BGFX_SAMPLER_COMPARE_LEQUAL));
+    if (!validFlags) {
+        log::warn("invalid depth texture flag using fallback");
+        m_flags = BGFX_TEXTURE_RT | BGFX_SAMPLER_COMPARE_LEQUAL;
+    }
+
+    m_renderTextureHandle.emplace_back(
+        bgfx::createTexture2D(size.x, size.y, false, 1, bgfx::TextureFormat::D16, m_flags));
+    m_framebufferHandle = bgfx::createFrameBuffer(m_renderTextureHandle.size(), m_renderTextureHandle.data());
+}
+
+void RenderTexture::recreate_render_texture(int width, int height) {
+    m_size.x = width;
+    m_size.y = height;
+
+    bgfx::reset((uint32_t)width, (uint32_t)height, BGFX_RESET_VSYNC | BGFX_RESET_MSAA_X2);
+    bgfx::setViewClear(m_id, BGFX_CLEAR_COLOR | BGFX_CLEAR_DEPTH | BGFX_CLEAR_STENCIL, (uint32_t)m_clearColor);
+    bgfx::setViewRect(m_id, 0, 0, width, height);
+    bgfx::setViewFrameBuffer(m_id, BGFX_INVALID_HANDLE);  // DRAW INTO BACK BUFFER
+    // TODO FB MANAGER SET ACTIVE FRAME BUFFER WITH "FrameBufferType"
+    // bgfx::setViewFrameBuffer(m_id, m_framebufferHandle);
+    // TODO SHADER TO PASS FBOS INTO // OR IMGUI IMAGE FOR EACH RT / FBO
+}
+
+void RenderTexture::set_view_projection(const mat4& view, const mat4& projection) {
+    bgfx::setViewTransform(m_id, &view[0][0], &projection[0][0]);
+}
+
+void RenderTexture::set_state() {
+    bgfx::setState(m_id, m_state);
+}
+
+void RenderTexture::update_state(const uint64_t& state) {
+    m_state = state;
+}
+
+void RenderTexture::destroy() {
+    for (auto& tex : m_renderTextureHandle) {
+        bgfx::destroy(tex);
+    }
+    bgfx::destroy(m_framebufferHandle);
+}
+
+void RenderTexture::clear_framebuffer() {
+    bgfx::setViewClear(m_id, BGFX_CLEAR_COLOR | BGFX_CLEAR_DEPTH, (uint32_t)m_clearColor);
+}
+
+}  // namespace knot

--- a/core/src/window.cpp
+++ b/core/src/window.cpp
@@ -79,7 +79,7 @@ void Window::window_size_callback(GLFWwindow* window, int width, int height) {
     self->set_window_resize_flag(true);
 }
 void Window::recreate_framebuffer(int width, int height) {
-    m_engine.get_forward_render_module().lock()->recreate_framebuffer(width, height);
+    m_engine.get_framebuffer_manager_module().lock()->recreate_framebuffer(width, height);
 }
 
 void Window::setup_callbacks() {

--- a/core/src/window.cpp
+++ b/core/src/window.cpp
@@ -47,18 +47,9 @@ Window::Window(int width, int height, std::string title, Engine& engine)
     init.platformData.nwh = (void*)(std::uintptr_t)glfwGetX11Window(m_window);
 #endif
 
-    init.resolution.width = (std::uint32_t)m_width;
-    init.resolution.height = (std::uint32_t)m_height;
-    init.resolution.reset = BGFX_RESET_VSYNC | BGFX_RESET_MSAA_X2;
-
     int bgfx_init_res = bgfx::init(init);
 
     KNOTING_ASSERT_MESSAGE(bgfx_init_res != 0, "Failed to initialize bgfx");
-
-    m_viewId = 0;
-    bgfx::setViewClear(m_viewId, BGFX_CLEAR_COLOR | BGFX_CLEAR_DEPTH, 0x303030ff);
-    bgfx::setViewRect(m_viewId, 0, 0, std::uint16_t(m_width), std::uint16_t(m_height));
-    log::debug("BGFX initialized");
 }
 
 Window::~Window() {


### PR DESCRIPTION
rendering can be done to frame buffers instead of directly to the back buffer.
Created all frame buffers that will be needed for the port of my BRDF / IBL / shadow shader from openGL 
Created Render Texture that is used for FBO and also will be used for the decal shader in the future
Added enum of Framebuffers in types.h

Recreate framebuffer now also calls the framebuffer manager instead of calling the forward renderer
removed some init bgfx data that was breaking the backbuffer